### PR TITLE
default export needs to return itself so that the properties are still available (to match the docs)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,10 @@ if (global.Promise) {
   });
 }
 
-let configure = opts => event.configure(opts);
+function configure(opts) {
+  event.configure(opts);
+  return configure;
+}
 
 configure.asyncTracker = require("./async_tracker");
 configure.customContext = event.customContext;

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,0 +1,19 @@
+test("the default export from the package has asyncTracker and customContext properties", () => {
+  const honeyMagic = require("./");
+  expect(honeyMagic.asyncTracker).toBeDefined();
+  expect(honeyMagic.customContext).toBeDefined();
+});
+
+test("the default export function returns itself, so the properties are still there.", () => {
+  const honeyMagic = require("./");
+  let rv = honeyMagic();
+  expect(rv).toBe(honeyMagic);
+  expect(rv.asyncTracker).toBeDefined();
+  expect(rv.customContext).toBeDefined();
+});
+
+test("the function is idempotent.  call it as often as you want.", () => {
+  const honeyMagic = require("./");
+  honeyMagic();
+  honeyMagic();
+});


### PR DESCRIPTION

the `README` has this block:

```
var honeyMagic = require("honeycomb-nodejs-magic")();

.
.
.

honeyMagic.customContext.add("extra", val);
```

For that to work, we need the return value of the default export from our module to be the same function.

also add some tests.