### PR TITLE
first pass at graphql resolver magic

### DIFF
--- a/lib/magic.js
+++ b/lib/magic.js
@@ -13,6 +13,7 @@ const instrumentedModules = new Set([
   "bluebird",
   "sequelize",
   "child_process",
+  "graphql",
 ]);
 const instrumented = new Map();
 

--- a/lib/magic/graphql-magic.js
+++ b/lib/magic/graphql-magic.js
@@ -64,10 +64,8 @@ function wrapResolvers(schema) {
   });
 }
 
-// copied from
-// https://github.com/apollographql/graphql-extensions/blob/298ae014c614000b823b3ea908aba2d2091e40e2/src/index.ts#L188
-// with this PR applied
-// https://github.com/apollographql/graphql-extensions/pull/4
+// lifted from
+// https://github.com/apollographql/graphql-extensions/blob/a3135a9142b8f995af848fab61dfc610f319cbf0/src/index.ts#L166
 function whenResultIsFinished(result, callback) {
   if (result === null || typeof result === "undefined") {
     callback();

--- a/lib/magic/graphql-magic.js
+++ b/lib/magic/graphql-magic.js
@@ -1,0 +1,98 @@
+/* global require module */
+const tracker = require("../async_tracker"),
+  event = require("../event");
+
+let defaultFieldResolver;
+
+module.exports = instrumentGraphQL;
+function instrumentGraphQL(graphql) {
+  let newGraphQL = {};
+  for (let k of Object.getOwnPropertyNames(graphql)) {
+    let original = graphql[k];
+    let wrapped = original;
+
+    switch (k) {
+      case "GraphQLSchema":
+        wrapped = function(opts) {
+          let schema = new original(opts);
+          wrapResolvers(schema);
+          return schema;
+        };
+        break;
+      case "buildASTSchema":
+        wrapped = function(ast, options) {
+          let schema = original.apply(this, [ast, options]);
+          wrapResolvers(schema);
+          return schema;
+        };
+        break;
+      case "defaultFieldResolver":
+        defaultFieldResolver = original;
+        break;
+    }
+    newGraphQL[k] = wrapped;
+  }
+  return newGraphQL;
+}
+
+function wrapResolvers(schema) {
+  const typeMap = schema.getTypeMap();
+  Object.keys(typeMap).forEach(typeName => {
+    const type = typeMap[typeName];
+
+    if (!type.name.startsWith("__") && type.getFields /* && type instanceof GraphQLObjectType*/) {
+      const fields = type.getFields();
+      Object.keys(fields).forEach(fieldName => {
+        const field = fields[fieldName];
+
+        if (field.resolve || defaultFieldResolver) {
+          let original = field.resolve;
+
+          field.resolve = function(source, args, context, info) {
+            let tracked = tracker.getTracked();
+            if (!tracked) {
+              return original.apply(this, [source, args, context, info]);
+            }
+            let startTime = Date.now();
+            const result = (original || defaultFieldResolver)(source, args, context, info);
+
+            whenResultIsFinished(result, () => {
+              let duration_ms = (Date.now() - startTime) / 1000;
+              event.sendEvent(tracked, "graphql", startTime, "resolver", {
+                resolver: fieldName,
+                duration_ms,
+              });
+            });
+            return result;
+          };
+        }
+      });
+    }
+  });
+}
+
+// copied from
+// https://github.com/apollographql/graphql-extensions/blob/298ae014c614000b823b3ea908aba2d2091e40e2/src/index.ts#L188
+// with this PR applied
+// https://github.com/apollographql/graphql-extensions/pull/4
+function whenResultIsFinished(result, callback) {
+  if (result === null || typeof result === "undefined") {
+    callback();
+  } else if (typeof result.then === "function") {
+    result.then(callback, callback);
+  } else if (Array.isArray(result)) {
+    const promises = [];
+    result.forEach(value => {
+      if (value && typeof value.then === "function") {
+        promises.push(value);
+      }
+    });
+    if (promises.length > 0) {
+      Promise.all(promises).then(callback, callback);
+    } else {
+      callback();
+    }
+  } else {
+    callback();
+  }
+}

--- a/lib/magic/graphql-magic.js
+++ b/lib/magic/graphql-magic.js
@@ -19,13 +19,6 @@ function instrumentGraphQL(graphql) {
           return schema;
         };
         break;
-      case "buildASTSchema":
-        wrapped = function(ast, options) {
-          let schema = original.apply(this, [ast, options]);
-          wrapResolvers(schema);
-          return schema;
-        };
-        break;
       case "defaultFieldResolver":
         defaultFieldResolver = original;
         break;

--- a/lib/magic/graphql-magic.js
+++ b/lib/magic/graphql-magic.js
@@ -42,19 +42,19 @@ function wrapResolvers(schema) {
           let original = field.resolve;
 
           field.resolve = function(source, args, context, info) {
-            let tracked = tracker.getTracked();
-            if (!tracked) {
+            let magicContext = tracker.getTracked();
+            if (!magicContext) {
               return original.apply(this, [source, args, context, info]);
             }
-            let startTime = Date.now();
+
+            let ev = event.startEvent(magicContext, "graphql");
             const result = (original || defaultFieldResolver)(source, args, context, info);
 
             whenResultIsFinished(result, () => {
-              let duration_ms = (Date.now() - startTime) / 1000;
-              event.sendEvent(tracked, "graphql", startTime, "resolver", {
+              event.addContext({
                 resolver: fieldName,
-                duration_ms,
               });
+              event.finishEvent(ev, "resolver");
             });
             return result;
           };


### PR DESCRIPTION
graphql's compile step from ES2015 modules results in exports being unconfigurable properties.  since they're unconfigurable, we can't use `shimmer`.  Instead, create a new object and copy everything over, replacing the one entrypoint we need at the moment, the constructor for `GraphQLSchema`.  We walk the type map and wrap all field resolvers.

This technique shamelessly lifted from https://github.com/apollographql/graphql-extensions

Somewhat addresses #16. Adding events for validation and total execution would be nice too.