### PR TITLE
refactor instrumentExpress to be a lot less magic

### DIFF
--- a/lib/magic/express-magic.js
+++ b/lib/magic/express-magic.js
@@ -40,32 +40,15 @@ const magicMiddleware = (req, res, next) => {
 };
 
 let instrumentExpress = function(express) {
-  shimmer.wrap(express.Route.prototype, "use", function(original) {
-    return function(_fn) {
-      if (this.stack.length === 0) {
-        // insert our middleware
-        original.apply(this, [magicMiddleware]);
-      }
-
-      return original.apply(this, arguments);
-    };
+  const wrapper = function() {
+    const app = express();
+    app.use(magicMiddleware);
+    return app;
+  };
+  Object.keys(express).forEach((key) => {
+    wrapper[key] = express[key]
   });
-
-  // all the http methods supported need to be wrapped
-  methods.concat("all").forEach(method =>
-    shimmer.wrap(express.Route.prototype, method, function(original) {
-      return function(_fn) {
-        if (this.stack.length === 0) {
-          // insert our middleware
-          original.apply(this, [magicMiddleware]);
-        }
-
-        return original.apply(this, arguments);
-      };
-    })
-  );
-
-  return express;
+  return wrapper;
 };
 
 module.exports = instrumentExpress;


### PR DESCRIPTION
I have taken out a bunch of the magic when instrumenting Express.

Instead of returning the required `express` I return an anonymous function (on which I copy all keys of the original express). When the method is called I initialize express and immediately register a middleware.

This should solve all issues no registering #28 or registering multiple times #9.
Didn't have time to write tests, it is way way past bedtime here now.