### PR TITLE
warn if modules we instrument are required before we are

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,21 +1,10 @@
 /* global require module */
-const Module = require("module"),
-  shimmer = require("shimmer"),
-  event = require("./event"),
+const event = require("./event"),
   magic = require("./magic");
 
 function configure(opts = {}) {
   event.configure(opts);
-  magic.instrumentPreload();
-
-  if (!opts.__disableModuleLoadMagic) {
-    shimmer.wrap(Module, "_load", function(original) {
-      return function(request, parent, isMain) {
-        let mod = original.apply(this, [request, parent, isMain]);
-        return magic.instrumentLoad(mod, request, parent, opts[request] || {});
-      };
-    });
-  }
+  magic.configure(opts);
 
   return configure;
 }

--- a/lib/magic.js
+++ b/lib/magic.js
@@ -1,7 +1,8 @@
-/* global require exports __dirname global */
+/* global require exports __dirname global console */
 const debug = require("debug")("honeycomb-magic:magic"),
   shimmer = require("shimmer"),
-  tracker = require("./async_tracker");
+  tracker = require("./async_tracker"),
+  Module = require("module");
 
 const instrumentedModules = new Set([
   "express",
@@ -24,7 +25,7 @@ const magicPath = name => {
 };
 
 let preloadDone = false;
-exports.instrumentPreload = () => {
+const instrumentPreload = (exports.instrumentPreload = () => {
   if (preloadDone) {
     return;
   }
@@ -44,9 +45,9 @@ exports.instrumentPreload = () => {
       return original.apply(this, args);
     };
   });
-};
+});
 
-exports.instrumentLoad = (mod, loadRequest, parent, opts = {}) => {
+const instrumentLoad = (exports.instrumentLoad = (mod, loadRequest, parent, opts = {}) => {
   if (
     parent.id.indexOf("node_modules/honeycomb-nodejs-magic/") !== -1 ||
     !instrumentedModules.has(loadRequest)
@@ -71,6 +72,46 @@ exports.instrumentLoad = (mod, loadRequest, parent, opts = {}) => {
   }
   instrumented.set(loadRequest, new_mod);
   return new_mod;
+});
+
+const checkForAlreadyRequiredModules = () => {
+  let modulesRequired = [];
+
+  for (let m of instrumentedModules.values()) {
+    try {
+      // try to resolve our known modules in the context of the main module
+      let resolvedPath = require.resolve(m, { paths: require.main.paths });
+
+      // if the resolved path is in the cache, the module has been required.
+      if (require.cache[resolvedPath]) {
+        modulesRequired.push(m);
+      }
+    } catch (e) {
+      // require.resolve() throws if it can't find a module. we can safely
+      // ignore it and continue our loop (it just means that the app requiring
+      // us doesn't use that module.)
+    }
+  }
+  if (modulesRequired.length > 0) {
+    console.error(
+      `The following modules were required before honeycomb-nodejs-magic: ${modulesRequired}
+These modules will not be instrumented.  Please ensure honeycomb-nodejs-magic is required first.`
+    );
+  }
+};
+
+exports.configure = (opts = {}) => {
+  if (!opts.__disableModuleLoadMagic) {
+    checkForAlreadyRequiredModules();
+
+    shimmer.wrap(Module, "_load", function(original) {
+      return function(request, parent, isMain) {
+        let mod = original.apply(this, [request, parent, isMain]);
+        return instrumentLoad(mod, request, parent, opts[request] || {});
+      };
+    });
+  }
+  instrumentPreload();
 };
 
 exports.clearInstrumentationForTesting = () => {


### PR DESCRIPTION
Iterate through our known instrumented modules and resolve them in the context of the main module (this last part is important - if we don't pass `require.main.paths`, the resolve call will look for them in _our_ `node_modules` 🤦‍♂️ )  The main module might not always be the place where we need to resolve things, but maybe this is the best we can do?

Also take the opportunity to move the magic config stuff into `magic.js`.
