### PR TITLE
propagate custom context to all events

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,20 +181,7 @@ Instrumented only for context propagation
 
 # Adding additional context
 
-The package instrumentations will send context to honeycomb about the actual requests and queries, but they can't automatically capture all context that you might want.
-If there's additional fields you'd like to include in events, you can use the `customContext` interface:
-
-```
-var honeycomb = require("honeycomb-beeline")();
-
-.
-.
-.
-
-honeycomb.customContext.add("extra", val);
-```
-
-This will cause an extra column (`custom.extra`) to be added to your dataset.
+See [docs/CustomContext.md](https://github.com/honeycombio/beeline-nodejs/blob/master/docs/CustomContext.md)
 
 # Troubleshooting
 
@@ -204,4 +191,4 @@ Use the `DEBUG=honeycomb-beeline:*` environment variable to produce debug output
 
 # Footnotes
 
-1. For the currently limited set of supported packages, and only until you realize how powerful added custom instrumentation can make things :)
+1.  For the currently limited set of supported packages, and only until you realize how powerful added custom instrumentation can make things :)

--- a/docs/CustomContext.md
+++ b/docs/CustomContext.md
@@ -14,7 +14,7 @@ const honey = require("honeycomb-beeline")();
 honey.customContext.add("extra", val);
 ```
 
-This will cause an extra column (`custom.extra`) to be added to your dataset, and the value you add will be sent along with all events within the current request that are generated after that line.
+This will cause an extra column (`app.extra`) to be added to your dataset, and the value you add will be sent along with all events within the current request that are generated after that line.
 
 ## Examples
 

--- a/docs/CustomContext.md
+++ b/docs/CustomContext.md
@@ -1,0 +1,158 @@
+# Custom Context Propagation
+
+The builtin instrumentations will send context to honeycomb about the actual requests and queries, but they can't automatically capture all context that might be useful to you.
+
+If there are additional fields you'd like to include in events, you can use the `customContext` interface to add them:
+
+```
+const honey = require("honeycomb-beeline")();
+
+.
+.
+.
+
+honey.customContext.add("extra", val);
+```
+
+This will cause an extra column (`custom.extra`) to be added to your dataset, and the value you add will be sent along with all events within the current request that are generated after that line.
+
+## Examples
+
+in each of the examples below, the `customContext` usage is higlighted by a `/**/` comment in column 0.
+
+### Using callbacks
+
+```
+const honey = require("honeycomb-beeline")();
+
+const express = require("express"),
+      React = require("react"),
+      ReactDOM = require("react-dom/server"),
+      User = require("./user"),
+      UserView = require("./views/user);
+
+app.param('user', (req, res, next, id) => {
+    req.userId = id;
+    next();
+});
+
+app.get("/user/:user, (req, res, next) => {
+    // the underlying DB event called by User.find will _not_ contain the additional fields.
+    User.find(req.userId, (err, user) => {
+        if (err) {
+            return next(err);
+        }
+/**/    honey.customContext.add("user.id", user.id);
+/**/    honey.customContext.add("user.email", user.email);
+
+        // the express request event will contain the additional fields.
+
+        // the react renderToString event here will also contain the additional fields.
+        res.send(ReactDOM.renderToString(React.createElement(UserView, { user })));
+    })
+});
+```
+
+### Using promises
+
+```
+const honey = require("honeycomb-beeline")();
+
+const express = require("express"),
+      React = require("react"),
+      ReactDOM = require("react-dom/server"),
+      User = require("./user"),
+      UserView = require("./views/user);
+
+app.param('user', (req, res, next, id) => {
+    req.userId = id;
+    next();
+});
+
+app.get("/user/:user, (req, res, next) => {
+    // the underlying DB event called by User.find will _not_ contain the additional fields.
+    User.find(req.userId).then(user => {
+/**/    honey.customContext.add("user.id", user.id);
+/**/    honey.customContext.add("user.email", user.email);
+
+        // the express request event will contain the additional fields.
+
+        // the react renderToString event here will also contain the additional fields.
+        res.send(ReactDOM.renderToString(React.createElement(UserView, { user })));
+    }).catch(err => {
+        return next(err);
+    })
+});
+```
+
+### Using `async`/`await`
+
+```
+const honey = require("honeycomb-beeline")();
+
+const express = require("express"),
+      React = require("react"),
+      ReactDOM = require("react-dom/server"),
+      User = require("./user"),
+      UserView = require("./views/user);
+
+app.param('user', (req, res, next, id) => {
+    req.userId = id;
+    next();
+});
+
+app.get("/user/:user, async (req, res, next) => {
+    try {
+        // the underlying DB event called by User.find will _not_ contain the additional fields.
+        let user = await User.find(req.userId);
+
+/**/    honey.customContext.add("user.id", user.id);
+/**/    honey.customContext.add("user.email", user.email);
+
+        // the express request event will contain the additional fields.
+
+        // the react renderToString event here will also contain the additional fields.
+        res.send(ReactDOM.renderToString(React.createElement(UserView, { user })));
+    } catch(e) {
+        return next(e);
+    }
+});
+```
+
+### Doing the user lookup inside `app.param`
+
+Each of the three examples above do the user lookup inside the request handler, but it's a more common pattern to do the lookup within the `app.param` callback itself.
+Here's how it would look doing it that way with `async`/`await`.
+
+```
+const honey = require("honeycomb-beeline")();
+
+const express = require("express"),
+      React = require("react"),
+      ReactDOM = require("react-dom/server"),
+      User = require("./user"),
+      UserView = require("./views/user);
+
+app.param('user', async (req, res, next, id) => {
+    try {
+        let user = await User.find(id);
+        if (!user) {
+            next(new Error("No user found"));
+            return;
+        }
+        req.user = user;
+/**/    honey.customContext.add("user.id", user.id);
+/**/    honey.customContext.add("user.email", user.email);
+        next();
+    } catch(e) {
+        next(e);
+    }
+});
+
+app.get("/user/:user, (req, res, next) => {
+    // the express request event will still contain the additional fields.
+
+    // the react renderToString event here will also contain the additional fields.
+    res.send(ReactDOM.renderToString(React.createElement(UserView, { req.user })));
+});
+```

--- a/lib/event.js
+++ b/lib/event.js
@@ -48,6 +48,7 @@ const incr = (payload, key, val = 1) => {
 class MockEventAPI {
   constructor(opts) {
     this.constructorArg = opts;
+    this.customContext = {};
     this.eventStack = [];
     this.sentEvents = [];
     this.traceId = 0;
@@ -75,7 +76,7 @@ class MockEventAPI {
     return eventPayload;
   }
   finishEvent(ev, _rollup) {
-    Object.assign(ev, {
+    Object.assign(ev, this.customContext, {
       [schema.DURATION_MS]: 0,
       [schema.BEELINE_VERSION]: pkg.version,
     });
@@ -85,8 +86,10 @@ class MockEventAPI {
     this.sentEvents.push(ev);
   }
   addContext(map) {
-    const ev = this.eventStack[this.eventStack.length - 1];
-    Object.assign(ev, map);
+    Object.assign(this.customContext, map);
+  }
+  removeContext(key) {
+    delete this.customContext[key];
   }
 }
 
@@ -110,6 +113,7 @@ class LibhoneyEventAPI {
     let id = traceId || uuidv4();
     const requestContext = {
       id,
+      customContext: {},
       stack: [],
     };
     tracker.setTracked(requestContext);
@@ -203,6 +207,7 @@ class LibhoneyEventAPI {
       const ev = this.honey.newEvent();
       ev.timestamp = new Date(startTime);
       ev.add(payload);
+      ev.add(context.customContext);
       ev.add({
         [schema.INSTRUMENTATIONS]: active_instrumentations,
         [schema.INSTRUMENTATION_COUNT]: active_instrumentation_count,
@@ -218,13 +223,16 @@ class LibhoneyEventAPI {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    if (context.stack.length === 0) {
-      // this _really_ shouldn't happen.
-      debug("no payload to add context to.");
+    Object.assign(context.customContext, map);
+  }
+
+  removeContext(key) {
+    const context = tracker.getTracked();
+    if (!context) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    const currentPayload = context.stack[context.stack.length - 1];
-    Object.assign(currentPayload, map);
+    delete context.customContext[key];
   }
 
   dumpRequestContext() {
@@ -240,7 +248,10 @@ class LibhoneyEventAPI {
 
 const customContext = {
   add(key, val) {
-    eventAPI.addContext({ [schema.customColumn(key)]: val });
+    eventAPI.addContext({ [schema.customContext(key)]: val });
+  },
+  remove(key) {
+    eventAPI.removeContext(schema.customContext(key));
   },
 };
 

--- a/lib/event.test.js
+++ b/lib/event.test.js
@@ -1,4 +1,4 @@
-/* global require beforeEach afterEach test expect __dirname */
+/* global require beforeEach afterEach describe test expect __dirname */
 const path = require("path"),
   event = require("./event"),
   schema = require("./schema"),
@@ -137,4 +137,73 @@ test("sub-events will get manual tracing fields", () => {
   expect(subEventData[schema.TRACE_PARENT_ID]).toBe(reqEventData[schema.TRACE_SPAN_ID]);
   expect(subEventData[schema.TRACE_ID]).toBe(reqEventData[schema.TRACE_ID]);
   expect(subEventData[schema.TRACE_SPAN_NAME]).toBe("name2");
+});
+
+describe("custom context", () => {
+  test("it should be added to request events", () => {
+    const honey = event.apiForTesting().honey;
+
+    let requestPayload = event.startRequest("source", "name");
+
+    event.customContext.add("testKey", "testVal");
+
+    // finish the request
+    event.finishRequest(requestPayload);
+
+    let requestData = JSON.parse(honey.transmission.events[0].postData);
+    expect(requestData[schema.customContext("testKey")]).toBe("testVal");
+  });
+
+  test("removing it works too", () => {
+    const honey = event.apiForTesting().honey;
+
+    let requestPayload = event.startRequest("source", "name");
+
+    event.customContext.add("testKey", "testVal");
+
+    event.customContext.remove("testKey");
+
+    // finish the request
+    event.finishRequest(requestPayload);
+
+    let requestData = JSON.parse(honey.transmission.events[0].postData);
+    expect(requestData[schema.customContext("testKey")]).toBeUndefined();
+  });
+
+  test("it should be added to subevents sent after it was added", () => {
+    const honey = event.apiForTesting().honey;
+
+    let requestPayload = event.startRequest("source", "name");
+    let context = tracker.getTracked();
+
+    let eventPayload = event.startEvent(context, "source2", "name2");
+    event.finishEvent(eventPayload);
+
+    event.customContext.add("testKey", "testVal");
+
+    let eventPayload2 = event.startEvent(context, "source3", "name3");
+    event.finishEvent(eventPayload2);
+
+    // finish the request
+    event.finishRequest(requestPayload);
+
+    // libhoney should have been told to send two events
+    expect(honey.transmission.events.length).toBe(3);
+
+    let subEventData = JSON.parse(honey.transmission.events[0].postData);
+    let subEvent2Data = JSON.parse(honey.transmission.events[1].postData);
+    let reqEventData = JSON.parse(honey.transmission.events[2].postData);
+
+    // make sure we grabbed the right events
+    expect(reqEventData[schema.EVENT_TYPE]).toBe("source");
+    expect(subEventData[schema.EVENT_TYPE]).toBe("source2");
+    expect(subEvent2Data[schema.EVENT_TYPE]).toBe("source3");
+
+    // these should have the custom context
+    expect(reqEventData[schema.customContext("testKey")]).toBe("testVal");
+    expect(subEvent2Data[schema.customContext("testKey")]).toBe("testVal");
+
+    // but the first event (sent before the context was added) won't:
+    expect(subEventData[schema.customContext("testKey")]).toBeUndefined();
+  });
 });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -14,4 +14,4 @@ exports.TRACE_SPAN_ID = "trace.span_id";
 exports.TRACE_SERVICE_NAME = "service_name";
 exports.TRACE_SPAN_NAME = "name";
 
-exports.customContext = key => `custom.${key}`;
+exports.customContext = key => `app.${key}`;


### PR DESCRIPTION
Right now the `customContext` api adds to the current event.  This is useless for everything but the request event, since in all other cases the event is sent before transfer is controlled back to user code.

Switch to keeping track of custom context separately from event payloads, and add the entirety of custom context to each event before we send it.  For containing events (which request events are a simple 1-level case of), that means that we'll also add this context when popping the stack of events and sending.

By way of a terribly contrived example (also spelled out in `docs/CustomContext.md`):

```
1. request
  1.1 db call to look up user
  1.2 add custom context "user=some@email"
  1.3 SSR some react
```

the event generated by 1.1 won't include the custom context, since it's already been sent by the time we get to 1.2.  1.3 will contain the context, and so will 1 (since it contains 1.1 - 1.3, it will be sent _after_ them.)

Con of this approach is that it exposes the order we send events.  Pro is that it makes it possible to attach context to multiple events, and (while magic) it's at least explainable.

Fixes #35 

adding @maplebed / @samstokes for approach-signoff.  unless you also want to review code :)