### PR TITLE
trace propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+yarn-error.log

--- a/lib/event_api/index.js
+++ b/lib/event_api/index.js
@@ -48,6 +48,9 @@ module.exports = {
   addContext(map) {
     return eventAPI.addContext(map);
   },
+  removeContext(key) {
+    return eventAPI.removeContext(key);
+  },
   customContext: {
     add(key, val) {
       eventAPI.addContext({ [schema.customContext(key)]: val });

--- a/lib/event_api/libhoney.js
+++ b/lib/event_api/libhoney.js
@@ -52,7 +52,7 @@ module.exports = class LibhoneyEventAPI {
   }
 
   startRequest(metadataContext, traceId, parentSpanId) {
-    let id = traceId || uuidv4();
+    const id = traceId || uuidv4();
 
     if (this.ds && !this.ds.sample(id)) {
       // don't create the context at all if this request isn't going to send a trace
@@ -64,7 +64,7 @@ module.exports = class LibhoneyEventAPI {
       customContext: {},
       stack: [],
     });
-    return this.startEvent(metadataContext, undefined, parentSpanId);
+    return this.startEvent(metadataContext, id, parentSpanId);
   }
 
   finishRequest(ev) {

--- a/lib/event_api/libhoney.js
+++ b/lib/event_api/libhoney.js
@@ -45,10 +45,13 @@ module.exports = class LibhoneyEventAPI {
         optsWithoutSampleRate
       )
     );
-    this.honey.addField(schema.HOSTNAME, os.hostname());
+    this.honey.add({
+      [schema.HOSTNAME]: os.hostname(),
+      [schema.TRACE_SERVICE_NAME]: opts.serviceName,
+    });
   }
 
-  startRequest(metadataContext, traceId) {
+  startRequest(metadataContext, traceId, parentSpanId) {
     let id = traceId || uuidv4();
 
     if (this.ds && !this.ds.sample(id)) {
@@ -61,7 +64,7 @@ module.exports = class LibhoneyEventAPI {
       customContext: {},
       stack: [],
     });
-    return this.startEvent(metadataContext, id);
+    return this.startEvent(metadataContext, undefined, parentSpanId);
   }
 
   finishRequest(ev) {
@@ -69,10 +72,12 @@ module.exports = class LibhoneyEventAPI {
     tracker.deleteTracked();
   }
 
-  startEvent(metadataContext, spanId = uuidv4()) {
+  startEvent(metadataContext, spanId = uuidv4(), parentId = undefined) {
     let context = tracker.getTracked();
-    let parentId;
     if (context.stack.length > 0) {
+      if (parentId) {
+        debug("parentId supplied when there are already spans.. wrong.");
+      }
       parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
     }
     const eventPayload = Object.assign({}, metadataContext, {

--- a/lib/event_api/mock.js
+++ b/lib/event_api/mock.js
@@ -22,9 +22,8 @@ module.exports = class MockEventAPI {
     this.finishEvent(ev);
     tracker.deleteTracked();
   }
-  startEvent(metadataContext, spanId = undefined) {
+  startEvent(metadataContext, spanId = undefined, parentId = undefined) {
     let context = tracker.getTracked();
-    let parentId;
     if (context.stack.length > 0) {
       parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 const event = require("./event_api"),
-  instrumentation = require("./instrumentation");
+  instrumentation = require("./instrumentation"),
+  propagation = require("./propagation");
 
 function configure(opts = {}) {
   event.configure(opts);
@@ -11,5 +12,8 @@ function configure(opts = {}) {
 
 configure.asyncTracker = require("./async_tracker");
 configure.customContext = event.customContext;
+
+configure.marshalTraceContext = propagation.marshalTraceContext;
+configure.unmarshalTraceContext = propagation.unmarshalTraceContext;
 
 module.exports = configure;

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -32,7 +32,7 @@ const getTraceContext = (traceIdSource, req) => {
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
       typeof traceIdSource === "undefined"
-        ? ["X-Honeycomb-Trace", "X-Request-ID", "X-Amzn-Trace-Id"]
+        ? [propagation.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
         : [traceIdSource];
     let valueAndHeader = getValueFromHeaders(req, headers);
 
@@ -42,7 +42,7 @@ const getTraceContext = (traceIdSource, req) => {
     let { value, header } = valueAndHeader;
 
     switch (header) {
-      case "X-Honeycomb-Trace": {
+      case propagation.TRACE_HTTP_HEADER: {
         let parsed = propagation.unmarshalTraceContext(value);
         if (!parsed) {
           return {};

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -125,7 +125,11 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
     traceContext.spanId
   );
 
-  // TODO(toshok) add traceContext.context
+  if (traceContext.customContext) {
+    Object.keys(traceContext.customContext).forEach(k =>
+      event.customContext.add(k, traceContext.customContext[k])
+    );
+  }
 
   if (!ev) {
     // sampler has decided that we shouldn't trace this request

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -43,7 +43,7 @@ const getTraceContext = (traceIdSource, req) => {
 
     switch (header) {
       case "X-Honeycomb-Trace": {
-        let parsed = propagation.parseTraceContext(value);
+        let parsed = propagation.unmarshalTraceContext(value);
         if (!parsed) {
           return {};
         }

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -3,6 +3,7 @@ const onHeaders = require("on-headers"),
   tracker = require("../async_tracker"),
   schema = require("../schema"),
   event = require("../event_api"),
+  propagation = require("../propagation"),
   path = require("path"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
   debug = require("debug")(`${pkg.name}:express`);
@@ -27,26 +28,43 @@ const getValueFromHeaders = (req, headers) => {
   return undefined;
 };
 
-const getTraceId = (traceIdSource, req) => {
-  let traceId, source;
-
+const getTraceContext = (traceIdSource, req) => {
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
-      typeof traceIdSource === "undefined" ? ["X-Request-ID", "X-Amzn-Trace-Id"] : [traceIdSource];
-    let headerAndValue = getValueFromHeaders(req, headers);
+      typeof traceIdSource === "undefined"
+        ? ["X-Honeycomb-Trace", "X-Request-ID", "X-Amzn-Trace-Id"]
+        : [traceIdSource];
+    let valueAndHeader = getValueFromHeaders(req, headers);
 
-    if (headerAndValue) {
-      traceId = headerAndValue.value;
-      source = `${headerAndValue.header} http header`;
+    if (!valueAndHeader) {
+      return {};
+    }
+    let { value, header } = valueAndHeader;
+
+    switch (header) {
+      case "X-Honeycomb-Trace": {
+        let parsed = propagation.parseTraceContext(value);
+        if (!parsed) {
+          return {};
+        }
+        return Object.assign({}, parsed, {
+          source: `${header} http header`,
+        });
+      }
+
+      default: {
+        return {
+          traceId: value,
+          source: `${header} http header`,
+        };
+      }
     }
   } else {
-    traceId = traceIdSource(req);
-    if (traceId) {
-      source = "traceIdSource function";
-    }
+    return {
+      traceId: traceIdSource(req),
+      source: "traceIdSource function",
+    };
   }
-
-  return { traceId, source };
 };
 
 const getUserContext = (userContext, req) => {
@@ -82,13 +100,13 @@ const getUserContext = (userContext, req) => {
 };
 
 const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (req, res, next) => {
-  let traceIdContext = getTraceId(traceIdSource, req);
+  let traceContext = getTraceContext(traceIdSource, req);
   let ev = event.startRequest(
     {
       [schema.EVENT_TYPE]: "express",
       [schema.PACKAGE_VERSION]: packageVersion,
       [schema.TRACE_SPAN_NAME]: "request",
-      [schema.TRACE_ID_SOURCE]: traceIdContext.source,
+      [schema.TRACE_ID_SOURCE]: traceContext.source,
       "request.host": req.hostname,
       "request.base_url": req.baseUrl,
       "request.original_url": req.originalUrl,
@@ -103,8 +121,11 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
       "request.fresh": req.fresh,
       "request.xhr": req.xhr,
     },
-    traceIdContext.traceId
+    traceContext.traceId,
+    traceContext.spanId
   );
+
+  // TODO(toshok) add traceContext.context
 
   if (!ev) {
     // sampler has decided that we shouldn't trace this request

--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -55,7 +55,7 @@ let instrumentHTTP = (http, opts = {}) => {
 
       // shallow clone options.headers, adding our tracing headers in
       options.headers = Object.assign({}, options.headers, {
-        "X-Honeycomb-Trace": propagation.marshalTraceContext(tracker.getTracked()),
+        [propagation.TRACE_HTTP_HEADER]: propagation.marshalTraceContext(tracker.getTracked()),
       });
 
       if (cb) {

--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -2,7 +2,9 @@
 const url = require("url"),
   shimmer = require("shimmer"),
   event = require("../event_api"),
-  schema = require("../schema");
+  propagation = require("../propagation"),
+  schema = require("../schema"),
+  tracker = require("../async_tracker");
 
 let instrumentHTTP = (http, opts = {}) => {
   shimmer.wrap(http, "get", function(_original) {
@@ -25,6 +27,7 @@ let instrumentHTTP = (http, opts = {}) => {
       if (typeof options === "string") {
         options = url.parse(options);
       } else {
+        // shallow-clone options since we'll be modifying it below
         options = Object.assign({}, options);
       }
 
@@ -49,6 +52,11 @@ let instrumentHTTP = (http, opts = {}) => {
           return cb.apply(this, [res]);
         }
       };
+
+      // shallow clone options.headers, adding our tracing headers in
+      options.headers = Object.assign({}, options.headers, {
+        "X-Honeycomb-Trace": propagation.getTraceContext(tracker.getTracked()),
+      });
 
       if (cb) {
         return original.apply(this, [options, wrapped_cb]);

--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -55,7 +55,7 @@ let instrumentHTTP = (http, opts = {}) => {
 
       // shallow clone options.headers, adding our tracing headers in
       options.headers = Object.assign({}, options.headers, {
-        "X-Honeycomb-Trace": propagation.getTraceContext(tracker.getTracked()),
+        "X-Honeycomb-Trace": propagation.marshalTraceContext(tracker.getTracked()),
       });
 
       if (cb) {

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -1,6 +1,7 @@
 /* eslint-env node, jest */
 const http = require("http"),
   instrumentHttp = require("./http"),
+  propagation = require("../propagation"),
   schema = require("../schema"),
   tracker = require("../async_tracker"),
   event = require("../event_api");
@@ -14,6 +15,10 @@ instrumentHttp(http);
 let server;
 beforeAll(() => {
   server = http.createServer((req, res) => {
+    res.setHeader(
+      propagation.TRACE_HTTP_HEADER,
+      req.headers[propagation.TRACE_HTTP_HEADER.toLowerCase()]
+    );
     res.end();
   });
 
@@ -35,7 +40,10 @@ afterEach(() => {
 test("url as a string", done => {
   tracker.setTracked(newMockContext());
 
-  http.get("http://localhost:9009", _res => {
+  http.get("http://localhost:9009", res => {
+    expect(res.headers[propagation.TRACE_HTTP_HEADER.toLowerCase()]).toBe(
+      "1;trace_id=0,parent_id=50001,context=e30="
+    );
     expect(event._apiForTesting().sentEvents).toMatchObject([
       {
         [schema.EVENT_TYPE]: "http",
@@ -55,7 +63,10 @@ test("url as options", done => {
       hostname: "localhost",
       port: 9009,
     },
-    _res => {
+    res => {
+      expect(res.headers[propagation.TRACE_HTTP_HEADER.toLowerCase()]).toBe(
+        "1;trace_id=0,parent_id=50001,context=e30="
+      );
       expect(event._apiForTesting().sentEvents).toEqual([
         expect.objectContaining({
           [schema.EVENT_TYPE]: "http",

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -2,7 +2,9 @@
 const url = require("url"),
   shimmer = require("shimmer"),
   event = require("../event_api"),
-  schema = require("../schema");
+  propagation = require("../propagation"),
+  schema = require("../schema"),
+  tracker = require("../async_tracker");
 
 let instrumentHTTPS = (https, opts = {}) => {
   shimmer.wrap(https, "get", function(_original) {
@@ -25,6 +27,7 @@ let instrumentHTTPS = (https, opts = {}) => {
       if (typeof options === "string") {
         options = url.parse(options);
       } else {
+        // shallow-clone options since we'll be modifying it below
         options = Object.assign({}, options);
       }
 
@@ -49,6 +52,11 @@ let instrumentHTTPS = (https, opts = {}) => {
           return cb.apply(this, [res]);
         }
       };
+
+      // shallow clone options.headers, adding our tracing headers in
+      options.headers = Object.assign({}, options.headers, {
+        "X-Honeycomb-Trace": propagation.getTraceContext(tracker.getTracked()),
+      });
 
       if (cb) {
         return original.apply(this, [options, wrapped_cb]);

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -55,7 +55,7 @@ let instrumentHTTPS = (https, opts = {}) => {
 
       // shallow clone options.headers, adding our tracing headers in
       options.headers = Object.assign({}, options.headers, {
-        "X-Honeycomb-Trace": propagation.getTraceContext(tracker.getTracked()),
+        "X-Honeycomb-Trace": propagation.marshalTraceContext(tracker.getTracked()),
       });
 
       if (cb) {

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -55,7 +55,7 @@ let instrumentHTTPS = (https, opts = {}) => {
 
       // shallow clone options.headers, adding our tracing headers in
       options.headers = Object.assign({}, options.headers, {
-        "X-Honeycomb-Trace": propagation.marshalTraceContext(tracker.getTracked()),
+        [propagation.TRACE_HTTP_HEADER]: propagation.marshalTraceContext(tracker.getTracked()),
       });
 
       if (cb) {

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -15,11 +15,11 @@ const VERSION = "1";
 // PAYLOAD is a list of comma-separated params (k=v pairs), with no spaces.  recognized
 // keys + value types:
 //
-//  trace=${traceId}       - traceId is an opaque ascii string which shall not include ','
-//  span=${spanId}         - spanId is an opaque ascii string which shall not include ','
+//  trace_id=${traceId}    - traceId is an opaque ascii string which shall not include ','
+//  parent_id=${spanId}    - spanId is an opaque ascii string which shall not include ','
 //  context=${contextBlob} - contextBlob is a base64 encoded json object.
 //
-// ex: X-Honeycomb-Trace: 1;trace=weofijwoeifj,span=owefjoweifj,context=SGVsbG8gV29ybGQ=
+// ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
 
 exports.getTraceContext = getTraceContextv1;
 function getTraceContextv1(context) {
@@ -27,7 +27,7 @@ function getTraceContextv1(context) {
   let spanId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
   let contextToSend = { a: 1 };
 
-  return `${VERSION};trace=${traceId},span=${spanId},context=${Buffer.from(
+  return `${VERSION};trace_id=${traceId},parent_id=${spanId},context=${Buffer.from(
     JSON.stringify(contextToSend)
   ).toString("base64")}`;
 }
@@ -51,10 +51,10 @@ function parseTraceContextv1(payload) {
   clauses.forEach(cl => {
     let [k, v] = cl.split("=");
     switch (k) {
-      case "trace":
+      case "trace_id":
         traceId = v;
         break;
-      case "span":
+      case "parent_id":
         spanId = v;
         break;
       case "context":

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -5,6 +5,7 @@ const path = require("path"),
   schema = require("./schema");
 
 const VERSION = "1";
+exports.VERSION = VERSION;
 
 // assumes a header of the form:
 
@@ -21,29 +22,29 @@ const VERSION = "1";
 //
 // ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
 
-exports.getTraceContext = getTraceContextv1;
-function getTraceContextv1(context) {
+exports.marshalTraceContext = marshalTraceContextv1;
+function marshalTraceContextv1(context) {
   let traceId = context.id;
   let spanId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
-  let contextToSend = { a: 1 };
+  let contextToSend = context.customContext || {};
 
   return `${VERSION};trace_id=${traceId},parent_id=${spanId},context=${Buffer.from(
     JSON.stringify(contextToSend)
   ).toString("base64")}`;
 }
 
-exports.parseTraceContext = parseTraceContext;
-function parseTraceContext(context) {
-  let [version, payload] = context.trim().split(";");
+exports.unmarshalTraceContext = unmarshalTraceContext;
+function unmarshalTraceContext(contextStr) {
+  let [version, payload] = contextStr.trim().split(";");
   switch (version) {
     case "1":
-      return parseTraceContextv1(payload);
+      return unmarshalTraceContextv1(payload);
   }
   debug(`unrecognized trace context version ${version}.  ignoring.`);
   return;
 }
 
-function parseTraceContextv1(payload) {
+function unmarshalTraceContextv1(payload) {
   let clauses = payload.split(",");
 
   let traceId, spanId, contextb64;
@@ -76,10 +77,10 @@ function parseTraceContextv1(payload) {
     return;
   }
 
-  let context;
+  let customContext;
   if (contextb64) {
-    context = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
+    customContext = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
   }
 
-  return { traceId, spanId, context };
+  return { traceId, spanId, customContext };
 }

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -4,6 +4,8 @@ const path = require("path"),
   debug = require("debug")(`${pkg.name}:propagation`),
   schema = require("./schema");
 
+exports.TRACE_HTTP_HEADER = "X-Honeycomb-Trace";
+
 const VERSION = "1";
 exports.VERSION = VERSION;
 

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -1,0 +1,85 @@
+/* global require, exports, Buffer, __dirname */
+const path = require("path"),
+  pkg = require(path.join(__dirname, "..", "package.json")),
+  debug = require("debug")(`${pkg.name}:propagation`),
+  schema = require("./schema");
+
+const VERSION = "1";
+
+// assumes a header of the form:
+
+// VERSION;PAYLOAD
+
+// VERSION=1
+// =========
+// PAYLOAD is a list of comma-separated params (k=v pairs), with no spaces.  recognized
+// keys + value types:
+//
+//  trace=${traceId}       - traceId is an opaque ascii string which shall not include ','
+//  span=${spanId}         - spanId is an opaque ascii string which shall not include ','
+//  context=${contextBlob} - contextBlob is a base64 encoded json object.
+//
+// ex: X-Honeycomb-Trace: 1;trace=weofijwoeifj,span=owefjoweifj,context=SGVsbG8gV29ybGQ=
+
+exports.getTraceContext = getTraceContextv1;
+function getTraceContextv1(context) {
+  let traceId = context.id;
+  let spanId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+  let contextToSend = { a: 1 };
+
+  return `${VERSION};trace=${traceId},span=${spanId},context=${Buffer.from(
+    JSON.stringify(contextToSend)
+  ).toString("base64")}`;
+}
+
+exports.parseTraceContext = parseTraceContext;
+function parseTraceContext(context) {
+  let [version, payload] = context.trim().split(";");
+  switch (version) {
+    case "1":
+      return parseTraceContextv1(payload);
+  }
+  debug(`unrecognized trace context version ${version}.  ignoring.`);
+  return;
+}
+
+function parseTraceContextv1(payload) {
+  let clauses = payload.split(",");
+
+  let traceId, spanId, contextb64;
+
+  clauses.forEach(cl => {
+    let [k, v] = cl.split("=");
+    switch (k) {
+      case "trace":
+        traceId = v;
+        break;
+      case "span":
+        spanId = v;
+        break;
+      case "context":
+        contextb64 = v;
+        break;
+      default:
+        debug(`unrecognized key '${k}', skipping.`);
+        break;
+    }
+  });
+
+  if (!traceId) {
+    debug("no traceId in header");
+    return;
+  }
+
+  if (!spanId) {
+    debug("no spanId in header");
+    return;
+  }
+
+  let context;
+  if (contextb64) {
+    context = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
+  }
+
+  return { traceId, spanId, context };
+}

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -68,18 +68,23 @@ function unmarshalTraceContextv1(payload) {
   });
 
   if (!traceId) {
-    debug("no traceId in header");
+    debug("no trace_id in header");
     return;
   }
 
   if (!spanId) {
-    debug("no spanId in header");
+    debug("no parent_id in header");
     return;
   }
 
   let customContext;
   if (contextb64) {
-    customContext = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
+    try {
+      customContext = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
+    } catch (e) {
+      debug("couldn't decode context", e);
+      return;
+    }
   }
 
   return { traceId, spanId, customContext };

--- a/lib/propagation.test.js
+++ b/lib/propagation.test.js
@@ -1,0 +1,34 @@
+/* global require test expect */
+const propagation = require("./propagation"),
+  schema = require("./schema");
+
+// this context structure is the same as what the libhoney event api implementation generate.
+let testContext = {
+  id: "abcdef123456",
+  stack: [{ [schema.TRACE_SPAN_ID]: "0102030405" }],
+  customContext: {
+    userID: 1,
+    errorMsg: "failed to sign on",
+    toRetry: true,
+  },
+};
+
+test("version string prefix", () => {
+  expect(
+    propagation.marshalTraceContext(testContext).startsWith(`${propagation.VERSION};`)
+  ).toBeTruthy();
+});
+
+test("roundtrip", () => {
+  let contextStr = propagation.marshalTraceContext(testContext);
+
+  expect(propagation.unmarshalTraceContext(contextStr)).toEqual({
+    traceId: "abcdef123456",
+    spanId: "0102030405",
+    customContext: {
+      userID: 1,
+      errorMsg: "failed to sign on",
+      toRetry: true,
+    },
+  });
+});

--- a/lib/propagation.test.js
+++ b/lib/propagation.test.js
@@ -1,6 +1,7 @@
-/* global require test expect */
+/* global require describe test expect */
 const propagation = require("./propagation"),
-  schema = require("./schema");
+  schema = require("./schema"),
+  cases = require("jest-in-case");
 
 // this context structure is the same as what the libhoney event api implementation generate.
 let testContext = {
@@ -13,22 +14,69 @@ let testContext = {
   },
 };
 
-test("version string prefix", () => {
-  expect(
-    propagation.marshalTraceContext(testContext).startsWith(`${propagation.VERSION};`)
-  ).toBeTruthy();
+describe("marshaling", () => {
+  test("version string prefix", () => {
+    expect(
+      propagation.marshalTraceContext(testContext).startsWith(`${propagation.VERSION};`)
+    ).toBeTruthy();
+  });
 });
 
-test("roundtrip", () => {
-  let contextStr = propagation.marshalTraceContext(testContext);
-
-  expect(propagation.unmarshalTraceContext(contextStr)).toEqual({
-    traceId: "abcdef123456",
-    spanId: "0102030405",
-    customContext: {
-      userID: 1,
-      errorMsg: "failed to sign on",
-      toRetry: true,
+cases(
+  "unmarshaling",
+  opts => expect(propagation.unmarshalTraceContext(opts.contextStr)).toEqual(opts.value),
+  [
+    {
+      name: "unsupported version",
+      contextStr: "9999999;.....",
+      value: undefined,
     },
+    {
+      name: "v1 trace_id + parent_id, missing context",
+      contextStr: "1;trace_id=abcdef,parent_id=12345",
+      value: {
+        traceId: "abcdef",
+        spanId: "12345",
+      },
+    },
+    {
+      name: "v1, missing trace_id",
+      contextStr: "1;parent_id=12345",
+      value: undefined,
+    },
+    {
+      name: "v1, missing parent_id",
+      contextStr: "1;trace_id=12345",
+      value: undefined,
+    },
+    {
+      name: "v1, garbled context",
+      contextStr: "1;trace_id=abcdef,parent_id=12345,context=123~!@@&^@",
+      value: undefined,
+    },
+    {
+      name: "v1, unknown key (otherwise valid)",
+      contextStr: "1;trace_id=abcdef,parent_id=12345,something=unsupported",
+      value: {
+        traceId: "abcdef",
+        spanId: "12345",
+      },
+    },
+  ]
+);
+
+describe("roundtrip", () => {
+  test("works", () => {
+    let contextStr = propagation.marshalTraceContext(testContext);
+
+    expect(propagation.unmarshalTraceContext(contextStr)).toEqual({
+      traceId: "abcdef123456",
+      spanId: "0102030405",
+      customContext: {
+        userID: 1,
+        errorMsg: "failed to sign on",
+        toRetry: true,
+      },
+    });
   });
 });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -3,7 +3,8 @@
 exports.EVENT_TYPE = "meta.type"; // XXX(toshok) rename "type" to "source"?
 exports.NODE_VERSION = "meta.node_version";
 exports.BEELINE_VERSION = "meta.beeline_version";
-exports.PACKAGE_VERSION = "meta.version";
+exports.PACKAGE = "meta.package";
+exports.PACKAGE_VERSION = "meta.package_version";
 exports.INSTRUMENTATIONS = "meta.instrumentations";
 exports.INSTRUMENTATION_COUNT = "meta.instrumentation_count";
 exports.HOSTNAME = "meta.local_hostname";


### PR DESCRIPTION
marshal trace context (trace_id, parent_id, and custom context) into an http header in both http/https instrumentations, and unmarshal it in the express instrumentation.

The format of the header value is:

```
  ${VERSION};${PAYLOAD}
```

with version 1 of the payload looking like:

```
  trace_id=${incoming trace id},parent_id=${incoming parent span id},context=${base64 encoded stringified JSON object}
```

Both `trace_id` and `parent_id` are required.  `context` can be missing without error, and any other `key=value` is ignored.  If `trace_id` or `parent_id` is missing, or if `context` fails to decode/parse as JSON, the context is dropped.