### PR TITLE
[eslint] use eslint-env node + jest to clean up our eslint comments

### DIFF
--- a/lib/async_tracker.js
+++ b/lib/async_tracker.js
@@ -1,4 +1,4 @@
-/* global require module */
+/* eslint-env node */
 const async_hooks = require("async_hooks");
 
 class AsyncTracker {

--- a/lib/async_tracker.test.js
+++ b/lib/async_tracker.test.js
@@ -1,4 +1,4 @@
-/* global require test expect setTimeout */
+/* eslint-env node, jest */
 const tracker = require("./async_tracker");
 
 test("local (non-continuation-based) tracked access", () => {

--- a/lib/deterministic_sampler.js
+++ b/lib/deterministic_sampler.js
@@ -1,4 +1,4 @@
-/* global require module */
+/* eslint-env node */
 const createHash = require("crypto").createHash;
 
 const MAX_UINT32 = Math.pow(2, 32) - 1;

--- a/lib/deterministic_sampler.test.js
+++ b/lib/deterministic_sampler.test.js
@@ -1,4 +1,4 @@
-/* global require test expect */
+/* eslint-env node, jest */
 const DeterministicSampler = require("./deterministic_sampler");
 
 test("it works (sample datapoints)", () => {

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,4 +1,4 @@
-/* global require exports __dirname */
+/* eslint-env node */
 const libhoney = require("libhoney").default,
   os = require("os"),
   process = require("process"),

--- a/lib/event.test.js
+++ b/lib/event.test.js
@@ -1,4 +1,4 @@
-/* global require beforeEach afterEach describe test expect __dirname */
+/* eslint-env node, jest */
 const path = require("path"),
   event = require("./event"),
   schema = require("./schema"),

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-/* global require module */
+/* eslint-env node */
 const event = require("./event"),
   instrumentation = require("./instrumentation");
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,4 +1,4 @@
-/* global require test expect */
+/* eslint-env node, jest */
 test("the default export from the package has asyncTracker and customContext properties", () => {
   const beeline = require("./");
   expect(beeline.asyncTracker).toBeDefined();

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -1,4 +1,4 @@
-/* global require exports __dirname global console */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("./async_tracker"),
   Module = require("module"),

--- a/lib/instrumentation.test.js
+++ b/lib/instrumentation.test.js
@@ -1,4 +1,4 @@
-/* global require test expect */
+/* eslint-env node, jest */
 const instrumentation = require("./instrumentation");
 
 test("preload shims Promise.then", () => {

--- a/lib/instrumentation/bluebird.js
+++ b/lib/instrumentation/bluebird.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("../async_tracker");
 

--- a/lib/instrumentation/child_process.js
+++ b/lib/instrumentation/child_process.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("../async_tracker"),
   event = require("../event"),

--- a/lib/instrumentation/child_process.test.js
+++ b/lib/instrumentation/child_process.test.js
@@ -1,4 +1,4 @@
-/* global require expect test beforeAll */
+/* eslint-env node, jest */
 const child_process = require("child_process"),
   instrumentChildProcess = require("./child_process"),
   tracker = require("../async_tracker"),

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -1,4 +1,4 @@
-/* global require, module, __dirname */
+/* eslint-env node */
 const onHeaders = require("on-headers"),
   tracker = require("../async_tracker"),
   schema = require("../schema"),

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -1,4 +1,4 @@
-/* global __dirname require expect describe test beforeEach afterEach */
+/* eslint-env node, jest */
 const request = require("supertest"),
   path = require("path"),
   instrumentExpress = require("./express"),

--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const url = require("url"),
   shimmer = require("shimmer"),
   tracker = require("../async_tracker"),

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -1,4 +1,4 @@
-/* global require expect test beforeAll afterAll */
+/* eslint-env node, jest */
 const http = require("http"),
   instrumentHttp = require("./http"),
   schema = require("../schema"),

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const url = require("url"),
   shimmer = require("shimmer"),
   tracker = require("../async_tracker"),

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -1,4 +1,4 @@
-/* global require expect beforeAll test */
+/* eslint-env node, jest */
 const https = require("https"),
   instrumentHttps = require("./https"),
   schema = require("../schema"),

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("../async_tracker"),
   event = require("../event"),

--- a/lib/instrumentation/mongoose.js
+++ b/lib/instrumentation/mongoose.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("../async_tracker");
 

--- a/lib/instrumentation/mpromise.js
+++ b/lib/instrumentation/mpromise.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("../async_tracker");
 

--- a/lib/instrumentation/mysql2.js
+++ b/lib/instrumentation/mysql2.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("../async_tracker"),
   event = require("../event"),

--- a/lib/instrumentation/react-dom-server.js
+++ b/lib/instrumentation/react-dom-server.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const shimmer = require("shimmer"),
   tracker = require("../async_tracker"),
   event = require("../event"),

--- a/lib/instrumentation/react-dom-server.test.js
+++ b/lib/instrumentation/react-dom-server.test.js
@@ -1,4 +1,4 @@
-/* global require expect test beforeAll describe */
+/* eslint-env node, jest */
 const ReactDOMServer = require("react-dom/server"),
   React = require("react"),
   instrumentReactDOMServer = require("./react-dom-server"),

--- a/lib/instrumentation/sequelize.js
+++ b/lib/instrumentation/sequelize.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 const instrumentBluebird = require("./bluebird");
 
 let instrumentSequelize = sequelize => {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,4 +1,4 @@
-/* global exports */
+/* eslint-env node */
 
 exports.EVENT_TYPE = "meta.type"; // XXX(toshok) rename "type" to "source"?
 exports.NODE_VERSION = "meta.node_version";


### PR DESCRIPTION
Stop listing every global we use.  it's annoying and error-prone.  Just tell eslint where we expect to run the code and let it do its thing.
