### PR TITLE
add event.traceActive and use it in instrumentations

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -281,6 +281,9 @@ const customContext = {
 exports.configure = configure;
 exports.apiForTesting = apiForTesting;
 exports.resetForTesting = resetForTesting;
+exports.traceActive = function traceActive() {
+  return !!tracker.getTracked();
+};
 exports.startRequest = function startRequest(source, name, traceId) {
   return eventAPI.startRequest(source, name, traceId);
 };

--- a/lib/instrumentation/child_process.js
+++ b/lib/instrumentation/child_process.js
@@ -8,7 +8,7 @@ function wrapExecLike(name, packageVersion) {
   return function(original) {
     return function(file, args /*, options, callback */) {
       let context = tracker.getTracked();
-      if (!context) {
+      if (!event.traceActive) {
         return original.apply(this, arguments);
       }
 

--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -19,7 +19,7 @@ let instrumentHTTP = (http, opts = {}) => {
   shimmer.wrap(http, "request", function(original) {
     return function(options, cb) {
       let context = tracker.getTracked();
-      if (!context) {
+      if (!event.traceActive()) {
         return original.apply(this, [options, cb]);
       }
 

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -19,7 +19,7 @@ let instrumentHTTPS = (https, opts = {}) => {
   shimmer.wrap(https, "request", function(original) {
     return function(options, cb) {
       let context = tracker.getTracked();
-      if (!context) {
+      if (!event.traceActive()) {
         return original.apply(this, [options, cb]);
       }
 

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -44,7 +44,7 @@ function instrumentMongodb(mongodb, opts = {}) {
     shimmer.wrap(mongodb.Collection.prototype, name, function(original) {
       return function(...args) {
         let context = tracker.getTracked();
-        if (!context) {
+        if (!event.traceActive()) {
           return original.apply(this, args);
         }
 

--- a/lib/instrumentation/mysql2.js
+++ b/lib/instrumentation/mysql2.js
@@ -11,7 +11,7 @@ let instrumentConnection = function(conn, packageVersion) {
         return original.apply(this, args);
       }
       let context = tracker.getTracked();
-      if (!context) {
+      if (!event.traceActive()) {
         return original.apply(this, args);
       }
 
@@ -43,7 +43,7 @@ let instrumentConnection = function(conn, packageVersion) {
         return original.apply(this, args);
       }
       let context = tracker.getTracked();
-      if (!context) {
+      if (!event.traceActive()) {
         return original.apply(this, args);
       }
 

--- a/lib/instrumentation/react-dom-server.js
+++ b/lib/instrumentation/react-dom-server.js
@@ -8,7 +8,7 @@ function shimRenderMethod(reactDOMServer, name, packageVersion) {
   shimmer.wrap(reactDOMServer, name, function(original) {
     return function(...args) {
       let context = tracker.getTracked();
-      if (!context) {
+      if (!event.traceActive()) {
         return original.apply(this, args);
       }
 


### PR DESCRIPTION
Currently the instrumentations fetch the current async_tracked context and check it for truthiness.  This isn't a very friendly api and isn't self-documenting at all.  Also I'd like to hide the async_tracker api entirely behind nicer things.