### PR TITLE
Fix bugs url in askForIssue

### DIFF
--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -197,7 +197,7 @@ module.exports = class LibhoneyEventAPI {
     logger(`-------------------
     ${pkg.name} error: ${msg}
     please paste this message (everything between the "----" lines) into an issue
-    at ${pkg.bugs}.  feel free to edit
+    at ${pkg.bugs.url}.  feel free to edit
     out any application stack frames if you'd rather not share those
     ${new Error().stack}
     ${this.dumpRequestContext()}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "type": "git",
     "url": "https://github.com/honeycombio/beeline-nodejs.git"
   },
-  "bugs": "https://github.com/honeycombio/beeline-nodejs/issues",
+  "bugs": {
+    "url": "https://github.com/honeycombio/beeline-nodejs/issues"
+  },
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
in our package.json we used to have:
```
  "bugs": "https://...."
```

and the code as written in `lib/api/libhoney.js` assumed that structure.  It worked fine locally (and when npm installing using a file path since that symlinks to the beeline source dir).  But once things are published to npm and installed from there, the `bugs` shorthand is expanded out:

```
  "bugs": {
    "url": "https://...."
  }
```

and askForIssue then prints out, e.g.:

```
honeycomb-beeline error: finishing an event with unfinished nested events. almost certainly not what we want.
please paste this message (everything between the "----" lines) into an issue
at [object Object].  feel free to edit
.
.
.
```

don't use the shorthand in our package.json at all, and modify libhoney.js to no longer assume it.