### PR TITLE
Remove more magic

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   },
   "extends": ["eslint:recommended"],
   "parserOptions": {
-    "ecmaVersion": 2015
+    "ecmaVersion": 2017
   },
   "rules": {
     "no-console": "off",

--- a/lib/async_tracker.test.js
+++ b/lib/async_tracker.test.js
@@ -46,3 +46,42 @@ test("callbacks are automatically attached to their parent context's payload", d
   expect(run).toBe(false);
   tracker.deleteTracked();
 });
+
+test("async/await chains with inbuilt Promises propagate the payload", done => {
+  const payload = {};
+  tracker.setTracked(payload);
+
+  chain().then(done, done);
+
+  async function chain() {
+    await delay();
+    await check();
+  }
+
+  async function delay() {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  async function check() {
+    expect(tracker.getTracked()).toBe(payload);
+    tracker.deleteTracked();
+  }
+});
+
+test("manual chains with inbuilt Promises propagate the payload", done => {
+  const payload = {};
+  tracker.setTracked(payload);
+
+  delay()
+    .then(check)
+    .then(done, done);
+
+  function delay() {
+    return new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  function check() {
+    expect(tracker.getTracked()).toBe(payload);
+    tracker.deleteTracked();
+  }
+});

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
 const shimmer = require("shimmer"),
-  tracker = require("./async_tracker"),
   Module = require("module"),
   process = require("process"),
   path = require("path"),
@@ -28,29 +27,6 @@ const instrumentationPath = name => {
   name = name.replace(/\//g, "-");
   return `${__dirname}/instrumentation/${name}`;
 };
-
-let preloadDone = false;
-const instrumentPreload = (exports.instrumentPreload = () => {
-  if (preloadDone) {
-    return;
-  }
-
-  preloadDone = true;
-  // this really shouldn't be here.  we could load the instrumentation modules all at configure time, and implement this as an instrumentation
-  // that isn't invoked in response to a require (instead running at startup.)
-  shimmer.wrap(global.Promise.prototype, "then", function(original) {
-    return function then(onFulfilled, onRejected) {
-      let args = [];
-      if (arguments.length > 0) {
-        args.push(tracker.bindFunction(onFulfilled));
-      }
-      if (arguments.length > 1) {
-        args.push(tracker.bindFunction(onRejected));
-      }
-      return original.apply(this, args);
-    };
-  });
-});
 
 // arguments are the same as to require.resolve.
 function getPackageVersion(request, options) {
@@ -154,7 +130,6 @@ exports.configure = (opts = {}) => {
       };
     });
   }
-  instrumentPreload();
 };
 
 exports.clearInstrumentationForTesting = () => {

--- a/lib/instrumentation.test.js
+++ b/lib/instrumentation.test.js
@@ -1,12 +1,6 @@
 /* eslint-env node, jest */
 const instrumentation = require("./instrumentation");
 
-test("preload shims Promise.then", () => {
-  expect(Promise.prototype.then.__wrapped).toBeUndefined();
-  instrumentation.instrumentPreload();
-  expect(Promise.prototype.then.__wrapped).toBe(true);
-});
-
 let createFakeExpress = () => {
   return {};
 };


### PR DESCRIPTION
Strikes me `instrumentPreload` is doubling up on heavy lifting `asyncHook.enable()` in `async_tracker.js` already takes care of:

> Installing async hooks via `async_hooks.createHook` enables promise execution tracking

 – [Node 8 `async_hooks` documentation](https://nodejs.org/docs/latest-v8.x/api/async_hooks.html#async_hooks_promise_execution_tracking)

Changes:

* Enable ES2017 linting
* Add `async / await` test
* Add manual Promise chain test
* Remove `instrumentPreload`