### PR TITLE
Don't try to use provided traceId as the next spanId

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -247,7 +247,7 @@ Returns an object containing the properties `traceId` and `parentSpanId`, which 
 example:
 
 ```javascript
-let { traceId, parentSpanId } = beeline.unmarshalTraceContext();
+let { traceId, parentSpanId } = beeline.unmarshalTraceContext(req.header[beeline.TRACE_HTTP_HEADER ]);
 
 let trace = startTrace({ name }, traceId, parentSpanId);
 ```

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -80,7 +80,7 @@ module.exports = class LibhoneyEventAPI {
       customContext: {},
       stack: [],
     });
-    return this.startSpan(metadataContext, id, parentSpanId);
+    return this.startSpan(metadataContext, undefined, parentSpanId);
   }
 
   finishTrace(ev) {


### PR DESCRIPTION
per Slack conversation, this doesn't seem quite right:

![image](https://user-images.githubusercontent.com/188595/48875361-80c02000-edad-11e8-9383-12331a24de7a.png)

`traceId` is already stuffed into the `context`, so we shouldn't be trying to pass it down via params anyway.