### PR TITLE
add a test to make sure that distributed tracing linkages are correct

### DIFF
--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -3,6 +3,7 @@ const path = require("path"),
   event = require("."),
   schema = require("../schema"),
   tracker = require("../async_tracker"),
+  propagation = require("../propagation"),
   pkg = require(path.join(__dirname, "..", "..", "package.json"));
 
 beforeEach(() =>
@@ -306,4 +307,67 @@ describe("custom context", () => {
     // but the first event (sent before the context was added) won't:
     expect(subEventData[schema.customContext("testKey")]).toBeUndefined();
   });
+});
+
+test("distributed tracing linkage is correct", () => {
+  const honey = event._apiForTesting().honey;
+
+  let rootSpan = event.startTrace({
+    [schema.TRACE_SPAN_NAME]: "root",
+  });
+  let traceId = rootSpan[schema.TRACE_ID];
+
+  let rootContext = tracker.getTracked();
+
+  let marshaledContext = propagation.marshalTraceContext(rootContext);
+
+  // this little bit of code simulates a downstream service.
+  tracker.setTracked(undefined);
+  let ctx = propagation.unmarshalTraceContext(marshaledContext);
+  let subserviceRootSpan = event.startTrace(
+    {
+      [schema.TRACE_SPAN_NAME]: "sub",
+    },
+    ctx.traceId,
+    ctx.parentSpanId
+  );
+
+  let subserviceSubspan = event.startSpan({
+    [schema.TRACE_SPAN_NAME]: "subspan",
+  });
+  event.finishSpan(subserviceSubspan);
+  event.finishTrace(subserviceRootSpan);
+  // end of downstream service.
+
+  // reinstate the root service's context and finish the trace there.
+  tracker.setTracked(rootContext);
+  event.finishTrace(rootSpan);
+
+  // libhoney should have been told to send three events
+  expect(honey.transmission.events.length).toBe(3);
+
+  let subSpanEventData = JSON.parse(honey.transmission.events[0].postData);
+  let subTraceEventData = JSON.parse(honey.transmission.events[1].postData);
+  let rootEventData = JSON.parse(honey.transmission.events[2].postData);
+
+  // make sure we grabbed the right events
+  expect(subSpanEventData[schema.TRACE_SPAN_NAME]).toBe("subspan");
+  expect(subTraceEventData[schema.TRACE_SPAN_NAME]).toBe("sub");
+  expect(rootEventData[schema.TRACE_SPAN_NAME]).toBe("root");
+
+  // make sure linkage is correct
+  expect(subSpanEventData[schema.TRACE_ID]).toBe(traceId);
+  expect(subTraceEventData[schema.TRACE_ID]).toBe(traceId);
+  expect(rootEventData[schema.TRACE_ID]).toBe(traceId);
+
+  expect(subSpanEventData[schema.TRACE_PARENT_ID]).toBe(subTraceEventData[schema.TRACE_SPAN_ID]);
+  expect(subTraceEventData[schema.TRACE_PARENT_ID]).toBe(rootEventData[schema.TRACE_SPAN_ID]);
+  expect(rootEventData[schema.TRACE_PARENT_ID]).toBeUndefined();
+
+  // we should have 3 span ids
+  let s = new Set();
+  s.add(subSpanEventData[schema.TRACE_SPAN_ID]);
+  s.add(subTraceEventData[schema.TRACE_SPAN_ID]);
+  s.add(rootEventData[schema.TRACE_SPAN_ID]);
+  expect(s.size).toBe(3);
 });


### PR DESCRIPTION
add a test that failed before 0e7bfbe1fb669b646d9c099634788a1f737e5d5a and passes after.