### PR TITLE
Provide span to withSpan()'s fn param

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -196,7 +196,7 @@ beeline.finishSpan(parentSpan);
 
 #### withSpan()
 
-If you're doing something synchronously (looping, for instance, or using a synchronous node api) you can use `withSpan` to wrap this operation. It safely wraps the invocation of `fn` with `startSpan()` and `finishSpan()` calls. It returns the return value of fn, so can be used in a expression context.
+If you're doing something synchronously (looping, for instance, or using a synchronous node api) you can use `withSpan` to wrap this operation. It safely wraps the invocation of `fn` with `startSpan()` and `finishSpan()` calls, while providing `span` to the body of `fn` for adding further context. It returns the return value of fn, so can be used in a expression context.
 
 As with `startSpan()`, `metadataContext` is the map of initial properties for the span. The span created by `withSpan` is added as a child of the current span, and the child installed as current span for the execution of `fn`.
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -69,7 +69,7 @@ module.exports = {
   withSpan(metadataContext, fn, rollupKey) {
     const span = apiImpl.startSpan(metadataContext);
     try {
-      return fn();
+      return fn(span);
     } finally {
       apiImpl.finishSpan(span, rollupKey);
     }


### PR DESCRIPTION
Two compounding incentives:
1. I'm trying to set a custom field on a span **within** a trace, and (AFAICT) `beeline.customContext.add` adds the key/value pair to all active spans within that trace - not just the currently active span.
2. I'm wrapping a simple `return x` function body and want to use `withSpan` instead of `startSpan`.

Is it correct that the only way to set a field on a span **within** a trace is to explicitly modify the `span` map? e.g. `span['app.my_custom_field'] = "my_custom_value"`? The docs don't have an example and I can't quite figure out the right incantations to apply the field to the child span only.

... so this fix (providing the `span` to the body of the `withSpan` `fn`) seems like a nicety that'll help with that, though not totally address incentive number 1.