### PR TITLE
fix mongodb instrumentation when using Promises

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -41,7 +41,7 @@ function instrumentMongodb(mongodb, opts = {}) {
 
         let eventName = `collection.${name}`;
 
-        api.startAsyncSpan(
+        return api.startAsyncSpan(
           {
             [schema.EVENT_TYPE]: "mongodb",
             [schema.PACKAGE_VERSION]: opts.packageVersion,
@@ -65,7 +65,7 @@ function instrumentMongodb(mongodb, opts = {}) {
             let rv = original.apply(this, populatedArgs);
             if (typeof rv.then === "function") {
               // it's a promise?
-              return rv.then(
+              rv.then(
                 () => {
                   api.finishSpan(span, eventName);
                 },
@@ -76,6 +76,7 @@ function instrumentMongodb(mongodb, opts = {}) {
                   api.finishSpan(span, eventName);
                 }
               );
+              return rv;
             }
 
             // otherwise it's a cursor.  we don't do a good job of instrumenting


### PR DESCRIPTION
The current mongodb instrumentation breaks applications which use any collection method which returns a Promise.

This MR fixes that by:
1. properly `return`ing the promise in all places
2. return the original promise (rv) and add instrumentation on a seperate promise chain
3. Replace `.then(success,fail)` anti-pattern with `.then(success).catch(fail)`. see http://bluebirdjs.com/docs/anti-patterns.html#the-.then for an explanation why this is an anti-pattern.

Besides a few other things this MR also fixes #89 