### PR TITLE
[http/https] clone the options we're going to mutate for formatting purposes

### DIFF
--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -23,18 +23,21 @@ let instrumentHTTP = (http, opts = {}) => {
 
       // let's make sure we have an object (or a url) for options.
       if (typeof options === "string") {
-        options = url.parse(options);
+        options = url.parse(options); // node 10 doesn't use url.parse (except as a fallback).  figure out how to handle that?
       } else {
-        // shallow-clone options since we'll be modifying it below
+        // shallow-clone options since we'll be modifying it below (adding our header)
         options = Object.assign({}, options);
       }
 
+      // another copy so we can normalize things
+      let formatOptions = Object.assign({}, options);
+
       // make sure options is populated enough for url.format to give us reasonable results.  these are all defaults from nodejs docs.
-      options.protocol = options.protocol || "http:";
-      options.port = options.port || 80;
-      options.pathname = options.path || "/";
-      if (!options.hostname && !options.host) {
-        options.hostname = "localhost";
+      formatOptions.protocol = formatOptions.protocol || "http:";
+      formatOptions.port = formatOptions.port !== 80 ? formatOptions.port : null;
+      formatOptions.pathname = formatOptions.path || "/";
+      if (!formatOptions.hostname && !formatOptions.host) {
+        formatOptions.hostname = "localhost";
       }
 
       return api.startAsyncSpan(
@@ -42,7 +45,7 @@ let instrumentHTTP = (http, opts = {}) => {
           [schema.EVENT_TYPE]: "http",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
           [schema.TRACE_SPAN_NAME]: options.method || "GET",
-          url: url.format(options),
+          url: url.format(formatOptions),
         },
         span => {
           let wrapped_cb = function(res) {

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -24,18 +24,21 @@ let instrumentHTTPS = (https, opts = {}) => {
 
       // let's make sure we have an object (or a url) for options.
       if (typeof options === "string") {
-        options = url.parse(options);
+        options = url.parse(options); // node 10 doesn't use url.parse (except as a fallback).  figure out how to handle that?
       } else {
-        // shallow-clone options since we'll be modifying it below
+        // shallow-clone options since we'll be modifying it below (adding our header)
         options = Object.assign({}, options);
       }
 
+      // another copy so we can normalize things
+      let formatOptions = Object.assign({}, options);
+
       // make sure options is populated enough for url.format to give us reasonable results.  these are all defaults from nodejs docs.
-      options.protocol = options.protocol || "https:";
-      options.port = options.port !== 443 ? options.port : null;
-      options.pathname = options.path || "/";
-      if (!options.hostname && !options.host) {
-        options.hostname = "localhost";
+      formatOptions.protocol = formatOptions.protocol || "https:";
+      formatOptions.port = formatOptions.port !== 443 ? formatOptions.port : null;
+      formatOptions.pathname = formatOptions.path || "/";
+      if (!formatOptions.hostname && !formatOptions.host) {
+        formatOptions.hostname = "localhost";
       }
 
       return api.startAsyncSpan(
@@ -43,7 +46,7 @@ let instrumentHTTPS = (https, opts = {}) => {
           [schema.EVENT_TYPE]: "https",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
           [schema.TRACE_SPAN_NAME]: options.method || "GET",
-          url: url.format(options),
+          url: url.format(formatOptions),
         },
         span => {
           // in node 8.x, https calls into http.  currently we don't have a way

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -68,7 +68,7 @@ test("url as options", done => {
               {
                 [schema.EVENT_TYPE]: "http",
                 [schema.TRACE_SPAN_NAME]: "GET",
-                url: "https://google.com:443/",
+                url: "http://google.com:443/",
               },
               {
                 [schema.EVENT_TYPE]: "https",


### PR DESCRIPTION
Fixes #104 

Instead of mutating the options we're going to pass to the normal node http layer, make another clone.  we normalize that separately and only use it for formatting.

We do still mutate the actual options, but only to pass in our header.