### PR TITLE
custom context should be sent to async spans as well

### DIFF
--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -7,7 +7,8 @@ const path = require("path"),
   pkg = require(path.join(__dirname, "..", "..", "package.json"));
 
 beforeEach(() =>
-  event.configure({ impl: "libhoney-event", transmission: "mock", writeKey: "abc123" }));
+  event.configure({ impl: "libhoney-event", transmission: "mock", writeKey: "abc123" })
+);
 afterEach(() => event._resetForTesting());
 test("libhoney default config", () => {
   const honey = event._apiForTesting().honey;
@@ -370,4 +371,24 @@ test("distributed tracing linkage is correct", () => {
   s.add(subTraceEventData[schema.TRACE_SPAN_ID]);
   s.add(rootEventData[schema.TRACE_SPAN_ID]);
   expect(s.size).toBe(3);
+});
+
+test("async spans share custom context", () => {
+  const honey = event._apiForTesting().honey;
+
+  let rootSpan = event.startTrace({
+    [schema.TRACE_SPAN_NAME]: "root",
+  });
+
+  event.customContext.add("custom", "value");
+
+  event.startAsyncSpan({}, span => {
+    event.finishSpan(span);
+  });
+  event.finishTrace(rootSpan);
+
+  expect(honey.transmission.events.length).toBe(2);
+
+  let asyncData = JSON.parse(honey.transmission.events[0].postData);
+  expect(asyncData["app.custom"]).toBe("value");
 });

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -112,13 +112,13 @@ module.exports = class LibhoneyEventAPI {
   startAsyncSpan(metadataContext, spanFn) {
     let parentId;
     let spanId = uuidv4();
-    let context = tracker.getTracked();
-    if (context.stack.length > 0) {
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+    let parentContext = tracker.getTracked();
+    if (parentContext.stack.length > 0) {
+      parentId = parentContext.stack[parentContext.stack.length - 1][schema.TRACE_SPAN_ID];
     }
 
     const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: context.id,
+      [schema.TRACE_ID]: parentContext.id,
       [schema.TRACE_SPAN_ID]: spanId,
       startTime: Date.now(),
       startTimeHR: process.hrtime(),
@@ -128,8 +128,8 @@ module.exports = class LibhoneyEventAPI {
     }
 
     let newContext = {
-      id: context.id,
-      customContext: {},
+      id: parentContext.id,
+      customContext: parentContext.customContext,
       stack: [eventPayload],
     };
 


### PR DESCRIPTION
Async spans are implemented essentially as separate traces with the async span as the root span (though they have the same trace id as their parent, and the parent_id is set correctly on this root span.)

We were initializing the `customContext` map the same way the root trace does, though, which means it was a new empty object, `{}`.  This means `customContext` isn't shared correctly, and the async spans won't have those fields added.

Instead of initializing it to a new object, just share (by ref) the same object across all async spans and their parent trace. 