### PR TITLE
When debugging, log the full span, including customContext

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ honeycombio/beeline-nodejs contributors:
 Chris Toshok
 Christine Yen
 Erwin van der Koogh
+Julian Ceipek

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -137,7 +137,6 @@ module.exports = class LibhoneyEventAPI {
   }
 
   finishSpan(ev, rollup) {
-    debug(`finishing span ${JSON.stringify(ev)}`);
     const context = tracker.getTracked();
     if (!context) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
@@ -205,6 +204,7 @@ module.exports = class LibhoneyEventAPI {
         [schema.BEELINE_VERSION]: pkg.version,
         [schema.NODE_VERSION]: process.version,
       });
+      debug(`finished span ${JSON.stringify(ev.data)}`);
       if (this.ds) {
         ev.sampleRate = this.ds.sampleRate;
       }


### PR DESCRIPTION
I just discovered honeycomb today and tried to use it to observe my app. However, as soon as I started adding custom fields with `beeline-nodejs`, I couldn't figure out whether and how that data would be added to the events I was generating.

----

As per https://docs.honeycomb.io/beeline/nodejs/#troubleshooting-the-beeline, debugging with the `DEBUG` environment variable should allow users to see the content of their events:
> “The events I’m generating don’t contain the content I expect”
> Enable debug output (sent to STDOUT) by setting DEBUG=honeycomb-beeline:* in your environment. This will print the JSON representation of events to the terminal instead of sending them to Honeycomb. This lets you quickly see what’s getting sent and allows you to modify your code accordingly.

Unfortunately, the existing `debug()` call happens prior to the event containing fields added with `addContext`, which invalidates this suggested debugging strategy.

This pull request moves the `debug()` call to the bottom of the `finishSpan` function, right before the event is sent. It logs `ev.data` instead of `ev` because at the end of the function, the latter is shadowed by a `const` that contains recursive structures that cannot be passed to `JSON.stringify`.