### PR TITLE
Add presend and sampler hooks implementation.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ honeycombio/beeline-nodejs contributors:
 Chris Toshok
 Christine Yen
 Erwin van der Koogh
+Ally Weir

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -182,6 +182,29 @@ describe("sampler hook", () => {
       expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
     });
 
+    test("it falls back to deterministicSampler with sampleRate if non-function samplerHook provided", () => {
+      deterministicSampler.mockReset();
+      const mockSamplerHook = jest.fn(() => () => ({
+        shouldSample: true,
+        newSampleRate: 999,
+      }));
+      deterministicSampler.mockImplementation(mockSamplerHook);
+      event._resetForTesting();
+      event.configure({
+        impl: "libhoney-event",
+        transmission: "mock",
+        writeKey: "abc123",
+        sampleRate: 12345,
+        samplerHook: "I am invalid as I am not a function",
+      });
+
+      let eventPayload = event.startTrace({});
+      event.finishTrace(eventPayload);
+
+      expect(deterministicSampler).toHaveBeenCalledTimes(1);
+      expect(deterministicSampler).toHaveBeenCalledWith(12345);
+    });
+
     test("it updates the sampleRate of the event if shouldSample is true", () => {
       const mockSamplerHook = jest.fn(() => ({
         shouldSample: true,

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -4,7 +4,10 @@ const path = require("path"),
   schema = require("../schema"),
   tracker = require("../async_tracker"),
   propagation = require("../propagation"),
+  deterministicSampler = require("../deterministic_sampler"),
   pkg = require(path.join(__dirname, "..", "..", "package.json"));
+
+jest.mock("../deterministic_sampler");
 
 beforeEach(() =>
   event.configure({ impl: "libhoney-event", transmission: "mock", writeKey: "abc123" })
@@ -75,50 +78,160 @@ test("sample rates are propagated", () => {
   const honey = event._apiForTesting().honey;
   expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
 
-  let sampled = false;
-  while (!sampled) {
-    let requestPayload = event.startTrace({
-      [schema.EVENT_TYPE]: "source",
-      [schema.TRACE_SPAN_NAME]: "name",
+  let requestPayload = event.startTrace({
+    [schema.EVENT_TYPE]: "source",
+    [schema.TRACE_SPAN_NAME]: "name",
+  });
+
+  // starting a request creates a context
+  let context = tracker.getTracked();
+  expect(context).not.toBeUndefined();
+
+  // the stack consists solely of the request's event
+  expect(context.stack).toEqual([requestPayload]);
+  // and it should have these properties
+  expect(requestPayload[schema.EVENT_TYPE]).toBe("source");
+  let traceId = requestPayload[schema.TRACE_ID];
+  expect(traceId).not.toBeUndefined();
+  let startTime = requestPayload.startTime;
+  expect(startTime).not.toBeUndefined();
+
+  // libhoney shouldn't have been told to send anything yet
+  expect(honey.transmission.events).toEqual([]);
+
+  // finish the request
+  event.finishTrace(requestPayload);
+  expect(tracker.getTracked()).toBeUndefined(); // context should be cleared
+
+  // libhoney should have been told to send one event
+  expect(honey.transmission.events.length).toBe(1);
+  let sent = honey.transmission.events[0];
+  let postData = JSON.parse(sent.postData);
+  expect(sent.timestamp).toEqual(new Date(startTime));
+  expect(sent.sampleRate).toBe(10);
+  expect(postData[schema.EVENT_TYPE]).toBe("source");
+  expect(postData[schema.TRACE_SPAN_NAME]).toBe("name");
+  expect(postData[schema.TRACE_ID]).toBe(traceId);
+  expect(postData[schema.TRACE_PARENT_ID]).toBeUndefined();
+  expect(postData[schema.TRACE_SPAN_ID]).not.toBeUndefined();
+  expect(postData[schema.DURATION_MS]).not.toBeUndefined();
+});
+
+describe("sampler hook", () => {
+  describe("if samplerHook option provided", () => {
+    test("it enqueues event during finalSpan if shouldSample is true", () => {
+      const mockSamplerHook = jest.fn(() => ({
+        shouldSample: true,
+        newSampleRate: 123,
+      }));
+      event._resetForTesting();
+      event.configure({
+        impl: "libhoney-event",
+        transmission: "mock",
+        writeKey: "abc123",
+        samplerHook: mockSamplerHook,
+      });
+
+      let eventPayload = event.startTrace({});
+
+      expect(mockSamplerHook).toHaveBeenCalledTimes(0);
+
+      event.finishTrace(eventPayload);
+
+      expect(mockSamplerHook).toHaveBeenCalledTimes(1);
+      expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
     });
-    if (requestPayload === null) {
-      continue;
-    }
-    sampled = true;
 
-    // starting a request creates a context
-    let context = tracker.getTracked();
-    expect(context).not.toBeUndefined();
+    test("it does not enqueue event if shouldSample is false", () => {
+      const mockSamplerHook = jest.fn(() => ({
+        shouldSample: false,
+        newSampleRate: 123,
+      }));
+      event._resetForTesting();
+      event.configure({
+        impl: "libhoney-event",
+        transmission: "mock",
+        writeKey: "abc123",
+        samplerHook: mockSamplerHook,
+      });
 
-    // the stack consists solely of the request's event
-    expect(context.stack).toEqual([requestPayload]);
-    // and it should have these properties
-    expect(requestPayload[schema.EVENT_TYPE]).toBe("source");
-    let traceId = requestPayload[schema.TRACE_ID];
-    expect(traceId).not.toBeUndefined();
-    let startTime = requestPayload.startTime;
-    expect(startTime).not.toBeUndefined();
+      let eventPayload = event.startTrace({});
+      event.finishTrace(eventPayload);
 
-    // libhoney shouldn't have been told to send anything yet
-    expect(honey.transmission.events).toEqual([]);
+      expect(mockSamplerHook).toHaveBeenCalledTimes(1);
+      expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+    });
 
-    // finish the request
-    event.finishTrace(requestPayload);
-    expect(tracker.getTracked()).toBeUndefined(); // context should be cleared
+    test("it does not enqueue event if invalid samplerHook provided", () => {
+      const mockSamplerHook = jest.fn(() => ({
+        foo: "bar",
+        baz: false,
+      }));
+      event._resetForTesting();
+      event.configure({
+        impl: "libhoney-event",
+        transmission: "mock",
+        writeKey: "abc123",
+        samplerHook: mockSamplerHook,
+      });
 
-    // libhoney should have been told to send one event
-    expect(honey.transmission.events.length).toBe(1);
-    let sent = honey.transmission.events[0];
-    let postData = JSON.parse(sent.postData);
-    expect(sent.timestamp).toEqual(new Date(startTime));
-    expect(sent.sampleRate).toBe(10);
-    expect(postData[schema.EVENT_TYPE]).toBe("source");
-    expect(postData[schema.TRACE_SPAN_NAME]).toBe("name");
-    expect(postData[schema.TRACE_ID]).toBe(traceId);
-    expect(postData[schema.TRACE_PARENT_ID]).toBeUndefined();
-    expect(postData[schema.TRACE_SPAN_ID]).not.toBeUndefined();
-    expect(postData[schema.DURATION_MS]).not.toBeUndefined();
-  }
+      let eventPayload = event.startTrace({});
+      event.finishTrace(eventPayload);
+
+      expect(mockSamplerHook).toHaveBeenCalledTimes(1);
+      expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+    });
+
+    test("it updates the sampleRate of the event if shouldSample is true", () => {
+      const mockSamplerHook = jest.fn(() => ({
+        shouldSample: true,
+        newSampleRate: 999,
+      }));
+      event._resetForTesting();
+      event.configure({
+        impl: "libhoney-event",
+        transmission: "mock",
+        writeKey: "abc123",
+        samplerHook: mockSamplerHook,
+      });
+
+      let eventPayload = event.startTrace({});
+      event.finishTrace(eventPayload);
+
+      expect(event._apiForTesting().honey.transmission.events[0].sampleRate).toEqual(999);
+    });
+  });
+
+  describe("if no samplerHook given but valid sampleRate provided", () => {
+    test("the default deterministicSampler hook initialised and used", () => {
+      deterministicSampler.mockReset();
+      const mockSamplerHook = jest.fn(() => () => ({
+        shouldSample: true,
+        newSampleRate: 999,
+      }));
+      deterministicSampler.mockImplementation(mockSamplerHook);
+      event._resetForTesting();
+      event.configure({
+        impl: "libhoney-event",
+        transmission: "mock",
+        writeKey: "abc123",
+        sampleRate: 123,
+      });
+
+      let eventPayload = event.startTrace();
+
+      // initialisation
+      expect(deterministicSampler).toHaveBeenCalledTimes(1);
+      expect(deterministicSampler).toHaveBeenCalledWith(123);
+
+      event.finishTrace(eventPayload);
+
+      // verify initiliser not called again
+      expect(deterministicSampler).toHaveBeenCalledTimes(1);
+      // verify actual sampler hook returned from intiialiser called
+      expect(mockSamplerHook).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 test("ending events out of order isn't allowed", () => {

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -528,3 +528,44 @@ test("async spans share custom context", () => {
   let asyncData = JSON.parse(honey.transmission.events[0].postData);
   expect(asyncData["app.custom"]).toBe("value");
 });
+
+describe("presend hook", () => {
+  it("calls the presend hook function if provided", () => {
+    const mockPresendHook = jest.fn();
+    event._resetForTesting();
+    event.configure({
+      impl: "libhoney-event",
+      transmission: "mock",
+      writeKey: "abc123",
+      presendHook: mockPresendHook,
+    });
+
+    let eventPayload = event.startTrace({});
+
+    event.finishTrace(eventPayload);
+
+    expect(mockPresendHook).toHaveBeenCalledTimes(1);
+    expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+  });
+
+  it("doesn't call the presend hook if the event is not being sampled", () => {
+    const mockPresendHook = jest.fn();
+    const mockSamplerHook = jest.fn(() => ({ shouldSample: false, newSampleRate: 1 }));
+    event._resetForTesting();
+    event.configure({
+      impl: "libhoney-event",
+      transmission: "mock",
+      writeKey: "abc123",
+      samplerHook: mockSamplerHook,
+      presendHook: mockPresendHook,
+    });
+
+    let eventPayload = event.startTrace({});
+
+    event.finishTrace(eventPayload);
+
+    expect(mockSamplerHook).toHaveBeenCalledTimes(1);
+    expect(mockPresendHook).toHaveBeenCalledTimes(0);
+    expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+  });
+});

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -255,6 +255,22 @@ describe("sampler hook", () => {
       expect(mockSamplerHook).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("if neither a samplerHook nor sampleRate given", () => {
+    test("send all events", () => {
+      event._resetForTesting();
+      event.configure({
+        impl: "libhoney-event",
+        transmission: "mock",
+        writeKey: "abc123",
+      });
+
+      let eventPayload = event.startTrace({});
+      event.finishTrace(eventPayload);
+
+      expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+    });
+  });
 });
 
 test("ending events out of order isn't allowed", () => {

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -122,7 +122,7 @@ describe("sampler hook", () => {
     test("it enqueues event during finalSpan if shouldSample is true", () => {
       const mockSamplerHook = jest.fn(() => ({
         shouldSample: true,
-        newSampleRate: 123,
+        sampleRate: 123,
       }));
       event._resetForTesting();
       event.configure({
@@ -145,7 +145,7 @@ describe("sampler hook", () => {
     test("it does not enqueue event if shouldSample is false", () => {
       const mockSamplerHook = jest.fn(() => ({
         shouldSample: false,
-        newSampleRate: 123,
+        sampleRate: 123,
       }));
       event._resetForTesting();
       event.configure({
@@ -186,7 +186,7 @@ describe("sampler hook", () => {
       deterministicSampler.mockReset();
       const mockSamplerHook = jest.fn(() => () => ({
         shouldSample: true,
-        newSampleRate: 999,
+        sampleRate: 999,
       }));
       deterministicSampler.mockImplementation(mockSamplerHook);
       event._resetForTesting();
@@ -208,7 +208,7 @@ describe("sampler hook", () => {
     test("it updates the sampleRate of the event if shouldSample is true", () => {
       const mockSamplerHook = jest.fn(() => ({
         shouldSample: true,
-        newSampleRate: 999,
+        sampleRate: 999,
       }));
       event._resetForTesting();
       event.configure({
@@ -230,7 +230,7 @@ describe("sampler hook", () => {
       deterministicSampler.mockReset();
       const mockSamplerHook = jest.fn(() => () => ({
         shouldSample: true,
-        newSampleRate: 999,
+        sampleRate: 999,
       }));
       deterministicSampler.mockImplementation(mockSamplerHook);
       event._resetForTesting();
@@ -550,7 +550,7 @@ describe("presend hook", () => {
 
   it("doesn't call the presend hook if the event is not being sampled", () => {
     const mockPresendHook = jest.fn();
-    const mockSamplerHook = jest.fn(() => ({ shouldSample: false, newSampleRate: 1 }));
+    const mockSamplerHook = jest.fn(() => ({ shouldSample: false, sampleRate: 1 }));
     event._resetForTesting();
     event.configure({
       impl: "libhoney-event",

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -222,12 +222,13 @@ module.exports = class LibhoneyEventAPI {
       });
 
       let presampled = false;
+      const eventDataForLogs = JSON.stringify(ev.data);
       if (this.samplerHook) {
-        debug(`executing sampler hook on event ev = ${JSON.stringify(ev.data)}`);
+        debug(`executing sampler hook on event ev = ${eventDataForLogs}`);
         const samplerHookResponse = this.samplerHook(ev.data);
         const keepEvent = samplerHookResponse.shouldSample;
         if (!keepEvent) {
-          debug("skipping event due to sampler hook sample ev = " + JSON.stringify(ev.data));
+          debug(`skipping event due to sampler hook sample ev = ${eventDataForLogs}`);
           return;
         }
 
@@ -239,12 +240,12 @@ module.exports = class LibhoneyEventAPI {
       }
 
       if (this.presendHook) {
-        debug(`executing presend hook on event ev = ${JSON.stringify(ev.data)}`);
+        debug(`executing presend hook on event ev = ${eventDataForLogs}`);
         this.presendHook(ev.data);
       }
 
       if (presampled) {
-        debug("enqueuing presampled event ev = " + JSON.stringify(ev.data));
+        debug(`enqueuing presampled event ev = ${eventDataForLogs}`);
         ev.sendPresampled();
       }
     });

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -232,8 +232,7 @@ module.exports = class LibhoneyEventAPI {
           return;
         }
 
-        const sampleRate = samplerHookResponse.sampleRate;
-        if (typeof sampleRate === "number") {
+        if (typeof samplerHookResponse.sampleRate === "number") {
           ev.sampleRate = samplerHookResponse.sampleRate;
         }
         presampled = true;

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -237,8 +237,7 @@ module.exports = class LibhoneyEventAPI {
       }
 
       if (this.presendHook) {
-        debug(`executing presend hook on event ev = ${eventDataForLogs}`);
-        this.presendHook(ev.data);
+        this.presendHook(ev);
       }
 
       debug(`enqueuing presampled event ev = ${eventDataForLogs}`);

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -216,6 +216,7 @@ module.exports = class LibhoneyEventAPI {
 
       let presampled = false;
       if (this.samplerHook) {
+        debug(`executing sampler hook on event ev = ${JSON.stringify(ev.data)}`);
         const samplerHookResponse = this.samplerHook(ev.data);
         const keepEvent = samplerHookResponse.shouldSample;
         if (!keepEvent) {

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -231,9 +231,9 @@ module.exports = class LibhoneyEventAPI {
           return;
         }
 
-        const newSampleRate = samplerHookResponse.newSampleRate;
-        if (newSampleRate !== undefined && typeof newSampleRate === "number") {
-          ev.sampleRate = samplerHookResponse.newSampleRate;
+        const sampleRate = samplerHookResponse.sampleRate;
+        if (typeof sampleRate === "number") {
+          ev.sampleRate = samplerHookResponse.sampleRate;
         }
         presampled = true;
       }

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -30,15 +30,15 @@ const getFilteredOptions = opts => {
 
 module.exports = class LibhoneyEventAPI {
   constructor(opts) {
-    if (typeof opts["samplerHook"] === "function") {
-      this.samplerHook = opts["samplerHook"];
+    if (typeof opts.samplerHook === "function") {
+      this.samplerHook = opts.samplerHook;
       debug("using custom samplerHook");
-    } else if (opts["samplerHook"] !== undefined) {
+    } else if (opts.samplerHook !== undefined) {
       debug(".samplerHook must be a function. ignoring");
     }
 
-    if (typeof opts["samplerHook"] !== "function") {
-      const sampleRate = opts["sampleRate"];
+    if (typeof opts.samplerHook !== "function") {
+      const sampleRate = opts.sampleRate;
 
       if (typeof sampleRate === "number") {
         this.samplerHook = deterministicSampler(sampleRate);
@@ -48,10 +48,10 @@ module.exports = class LibhoneyEventAPI {
       }
     }
 
-    if (typeof opts["presendHook"] === "function") {
-      this.presendHook = opts["presendHook"];
+    if (typeof opts.presendHook === "function") {
+      this.presendHook = opts.presendHook;
       debug("using custom presendHook");
-    } else if (opts["presendHook"] !== undefined) {
+    } else if (opts.presendHook !== undefined) {
       debug(".presendHook must be a function. ignoring");
     }
 

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -221,7 +221,6 @@ module.exports = class LibhoneyEventAPI {
         [schema.NODE_VERSION]: process.version,
       });
 
-      let presampled = false;
       const eventDataForLogs = JSON.stringify(ev.data);
       if (this.samplerHook) {
         debug(`executing sampler hook on event ev = ${eventDataForLogs}`);
@@ -235,7 +234,6 @@ module.exports = class LibhoneyEventAPI {
         if (typeof samplerHookResponse.sampleRate === "number") {
           ev.sampleRate = samplerHookResponse.sampleRate;
         }
-        presampled = true;
       }
 
       if (this.presendHook) {
@@ -243,10 +241,8 @@ module.exports = class LibhoneyEventAPI {
         this.presendHook(ev.data);
       }
 
-      if (presampled) {
-        debug(`enqueuing presampled event ev = ${eventDataForLogs}`);
-        ev.sendPresampled();
-      }
+      debug(`enqueuing presampled event ev = ${eventDataForLogs}`);
+      ev.sendPresampled();
     });
   }
 

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -246,9 +246,6 @@ module.exports = class LibhoneyEventAPI {
       if (presampled) {
         debug("enqueuing presampled event ev = " + JSON.stringify(ev.data));
         ev.sendPresampled();
-      } else {
-        debug("enqueuing event ev = " + JSON.stringify(ev.data));
-        ev.send();
       }
     });
   }

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -21,7 +21,7 @@ const incr = (payload, key, val = 1) => {
 const getFilteredOptions = opts => {
   let filteredOptions = {};
   Object.keys(opts).forEach(optionKey => {
-    if (optionKey !== "samplerHook") {
+    if (optionKey !== "samplerHook" || optionKey !== "presendHook") {
       filteredOptions[optionKey] = opts[optionKey];
     }
   });

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -18,18 +18,26 @@ const incr = (payload, key, val = 1) => {
   payload[key] = (payload[key] || 0) + val;
 };
 
+const getFilteredOptions = opts => {
+  let filteredOptions = {};
+  Object.keys(opts).forEach(optionKey => {
+    if (optionKey !== "samplerHook") {
+      filteredOptions[optionKey] = opts[optionKey];
+    }
+  });
+  return filteredOptions;
+};
+
 module.exports = class LibhoneyEventAPI {
   constructor(opts) {
-    if ("samplerHook" in opts) {
-      if (typeof opts["samplerHook"] === "function") {
-        this.samplerHook = opts["samplerHook"];
-        debug("using custom samplerHook");
-      } else {
-        debug(".samplerHook must be a function. ignoring");
-      }
+    if (typeof opts["samplerHook"] === "function") {
+      this.samplerHook = opts["samplerHook"];
+      debug("using custom samplerHook");
+    } else if (opts["samplerHook"] !== undefined) {
+      debug(".samplerHook must be a function. ignoring");
     }
 
-    if (!("samplerHook" in opts)) {
+    if (typeof opts["samplerHook"] !== "function") {
       const sampleRate = opts["sampleRate"];
 
       if (typeof sampleRate === "number") {
@@ -63,7 +71,7 @@ module.exports = class LibhoneyEventAPI {
           dataset: process.env["HONEYCOMB_DATASET"] || defaultName,
           userAgentAddition: `honeycomb-beeline/${pkg.version}`,
         },
-        opts
+        getFilteredOptions(opts)
       )
     );
     this.honey.add({

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -221,13 +221,12 @@ module.exports = class LibhoneyEventAPI {
         [schema.NODE_VERSION]: process.version,
       });
 
-      const eventDataForLogs = JSON.stringify(ev.data);
       if (this.samplerHook) {
-        debug(`executing sampler hook on event ev = ${eventDataForLogs}`);
+        debug(`executing sampler hook on event ev = ${JSON.stringify(ev.data)}`);
         const samplerHookResponse = this.samplerHook(ev.data);
         const keepEvent = samplerHookResponse.shouldSample;
         if (!keepEvent) {
-          debug(`skipping event due to sampler hook sample ev = ${eventDataForLogs}`);
+          debug(`skipping event due to sampler hook sample ev = ${JSON.stringify(ev.data)}`);
           return;
         }
 
@@ -237,10 +236,11 @@ module.exports = class LibhoneyEventAPI {
       }
 
       if (this.presendHook) {
+        debug(`executing presend hook on event ev = ${JSON.stringify(ev.data)}`);
         this.presendHook(ev);
       }
 
-      debug(`enqueuing presampled event ev = ${eventDataForLogs}`);
+      debug(`enqueuing presampled event ev = ${JSON.stringify(ev.data)}`);
       ev.sendPresampled();
     });
   }

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -21,8 +21,12 @@ const incr = (payload, key, val = 1) => {
 module.exports = class LibhoneyEventAPI {
   constructor(opts) {
     if ("samplerHook" in opts) {
-      this.samplerHook = opts["samplerHook"];
-      debug("using custom samplerHook");
+      if (typeof opts["samplerHook"] === "function") {
+        this.samplerHook = opts["samplerHook"];
+        debug("using custom samplerHook");
+      } else {
+        debug(".samplerHook must be a function. ignoring");
+      }
     }
 
     if (!("samplerHook" in opts)) {

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -7,7 +7,7 @@ const libhoney = require("libhoney").default,
   url = require("url"),
   tracker = require("../async_tracker"),
   instrumentation = require("../instrumentation"),
-  DeterministicSampler = require("../deterministic_sampler"),
+  deterministicSampler = require("../deterministic_sampler"),
   schema = require("../schema"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
   debug = require("debug")(`${pkg.name}:event`);
@@ -20,19 +20,20 @@ const incr = (payload, key, val = 1) => {
 
 module.exports = class LibhoneyEventAPI {
   constructor(opts) {
-    let sampleRate;
-    let optsWithoutSampleRate = {};
-    Object.keys(opts).forEach(k => {
-      if (k === "sampleRate") {
-        sampleRate = opts[k];
-      } else {
-        optsWithoutSampleRate[k] = opts[k];
+    if ("samplerHook" in opts) {
+      this.samplerHook = opts["samplerHook"];
+      debug("using custom samplerHook");
+    }
+
+    if (!("samplerHook" in opts)) {
+      const sampleRate = opts["sampleRate"];
+
+      if (typeof sampleRate === "number") {
+        this.samplerHook = deterministicSampler(sampleRate);
+        debug("using deterministic sampler with .sampleRate provided.");
+      } else if (typeof sampleRate !== "undefined") {
+        debug(".sampleRate must be a number.  ignoring.");
       }
-    });
-    if (typeof sampleRate === "number") {
-      this.ds = new DeterministicSampler(sampleRate);
-    } else if (typeof sampleRate !== "undefined") {
-      debug(".sampleRate must be a number.  ignoring.");
     }
 
     let apiHost = process.env["HONEYCOMB_API_HOST"] || "https://api.honeycomb.io";
@@ -58,7 +59,7 @@ module.exports = class LibhoneyEventAPI {
           dataset: process.env["HONEYCOMB_DATASET"] || defaultName,
           userAgentAddition: `honeycomb-beeline/${pkg.version}`,
         },
-        optsWithoutSampleRate
+        opts
       )
     );
     this.honey.add({
@@ -69,11 +70,6 @@ module.exports = class LibhoneyEventAPI {
 
   startTrace(metadataContext, traceId, parentSpanId) {
     const id = traceId || uuidv4();
-
-    if (this.ds && !this.ds.sample(id)) {
-      // don't create the context at all if this request isn't going to send a trace
-      return null;
-    }
 
     tracker.setTracked({
       id,
@@ -205,10 +201,30 @@ module.exports = class LibhoneyEventAPI {
         [schema.BEELINE_VERSION]: pkg.version,
         [schema.NODE_VERSION]: process.version,
       });
-      if (this.ds) {
-        ev.sampleRate = this.ds.sampleRate;
+
+      let presampled = false;
+      if (this.samplerHook) {
+        const samplerHookResponse = this.samplerHook(ev.data);
+        const keepEvent = samplerHookResponse.shouldSample;
+        if (!keepEvent) {
+          debug("skipping event due to sampler hook sample ev = " + JSON.stringify(ev.data));
+          return;
+        }
+
+        const newSampleRate = samplerHookResponse.newSampleRate;
+        if (newSampleRate !== undefined && typeof newSampleRate === "number") {
+          ev.sampleRate = samplerHookResponse.newSampleRate;
+        }
+        presampled = true;
       }
-      ev.sendPresampled();
+
+      if (presampled) {
+        debug("enqueuing presampled event ev = " + JSON.stringify(ev.data));
+        ev.sendPresampled();
+      } else {
+        debug("enqueuing event ev = " + JSON.stringify(ev.data));
+        ev.send();
+      }
     });
   }
 

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -48,6 +48,13 @@ module.exports = class LibhoneyEventAPI {
       }
     }
 
+    if (typeof opts["presendHook"] === "function") {
+      this.presendHook = opts["presendHook"];
+      debug("using custom presendHook");
+    } else if (opts["presendHook"] !== undefined) {
+      debug(".presendHook must be a function. ignoring");
+    }
+
     let apiHost = process.env["HONEYCOMB_API_HOST"] || "https://api.honeycomb.io";
     let apiUrl = new url.URL(apiHost);
     let proxy;
@@ -229,6 +236,11 @@ module.exports = class LibhoneyEventAPI {
           ev.sampleRate = samplerHookResponse.newSampleRate;
         }
         presampled = true;
+      }
+
+      if (this.presendHook) {
+        debug(`executing presend hook on event ev = ${JSON.stringify(ev.data)}`);
+        this.presendHook(ev.data);
       }
 
       if (presampled) {

--- a/lib/deterministic_sampler.js
+++ b/lib/deterministic_sampler.js
@@ -13,7 +13,7 @@ module.exports = function(sampleRate) {
 
     return {
       shouldSample: sum.readUInt32BE(0) <= upperBound,
-      newSampleRate: sampleRate,
+      sampleRate: sampleRate,
     };
   };
 };

--- a/lib/deterministic_sampler.js
+++ b/lib/deterministic_sampler.js
@@ -1,18 +1,19 @@
 /* eslint-env node */
 const createHash = require("crypto").createHash;
+const schema = require("./schema");
 
 const MAX_UINT32 = Math.pow(2, 32) - 1;
 
-module.exports = class DeterministicSampler {
-  constructor(sampleRate) {
-    this.sampleRate = sampleRate;
-    this.upperBound = (MAX_UINT32 / sampleRate) >>> 0;
-  }
-
-  sample(determinant) {
-    let sum = createHash("sha1")
-      .update(determinant)
+module.exports = function(sampleRate) {
+  return function(eventData) {
+    const sum = createHash("sha1")
+      .update(eventData[schema.TRACE_ID])
       .digest();
-    return sum.readUInt32BE(0) <= this.upperBound;
-  }
+    const upperBound = (MAX_UINT32 / sampleRate) >>> 0;
+
+    return {
+      shouldSample: sum.readUInt32BE(0) <= upperBound,
+      newSampleRate: sampleRate,
+    };
+  };
 };

--- a/lib/deterministic_sampler.test.js
+++ b/lib/deterministic_sampler.test.js
@@ -1,13 +1,34 @@
 /* eslint-env node, jest */
-const DeterministicSampler = require("./deterministic_sampler");
+const deterministicSampler = require("./deterministic_sampler");
+const schema = require("./schema");
 
 test("it works (sample datapoints)", () => {
-  // taken from honeytail's test TestDeterministicSamplerDatapoints
-  let s = new DeterministicSampler(17);
-  expect(s.sample("hello")).toBe(false);
-  expect(s.sample("hello")).toBe(false);
-  expect(s.sample("world")).toBe(false);
-  expect(s.sample("this5")).toBe(true);
+  const testSampleRate = 17;
+  const testSampler = deterministicSampler(testSampleRate);
+
+  expect(
+    testSampler({
+      [schema.TRACE_ID]: "hello",
+    }).shouldSample
+  ).toBe(false);
+
+  expect(
+    testSampler({
+      [schema.TRACE_ID]: "hello",
+    }).shouldSample
+  ).toBe(false);
+
+  expect(
+    testSampler({
+      [schema.TRACE_ID]: "world",
+    }).shouldSample
+  ).toBe(false);
+
+  expect(
+    testSampler({
+      [schema.TRACE_ID]: "this5",
+    }).shouldSample
+  ).toBe(true);
 });
 
 const requestIDBytes = "abcdef0123456789";
@@ -43,11 +64,14 @@ test("it works (stastically)", () => {
   const testSampleRates = [1, 2, 10];
 
   for (let sampleRate of testSampleRates) {
-    let ds = new DeterministicSampler(sampleRate);
     let nSampled = 0;
 
     for (let i = 0; i < nRequestIDs; i++) {
-      if (ds.sample(randomRequestID())) {
+      const testSampler = deterministicSampler(sampleRate);
+      const testEventData = {
+        [schema.TRACE_ID]: randomRequestID(),
+      };
+      if (testSampler(testEventData).shouldSample) {
         nSampled++;
       }
     }

--- a/lib/deterministic_sampler.test.js
+++ b/lib/deterministic_sampler.test.js
@@ -64,10 +64,10 @@ test("it works (stastically)", () => {
   const testSampleRates = [1, 2, 10];
 
   for (let sampleRate of testSampleRates) {
+    const testSampler = deterministicSampler(sampleRate);
     let nSampled = 0;
 
     for (let i = 0; i < nRequestIDs; i++) {
-      const testSampler = deterministicSampler(sampleRate);
       const testEventData = {
         [schema.TRACE_ID]: randomRequestID(),
       };


### PR DESCRIPTION
### Aim
To allow users of the library to define their own `samplerHook` function that takes an event's data and can make a sampling decision based on that. Also allow a `presendHook` function to be defined and called to enrich an event with further context.

### Reasoning (for samplerHook)
Dynamic sampling is something that some of the other Honeycomb libraries are capable of and it is really helpful!

### Discussion
Moved all sampling behaviour to `finishSpan()`, following the pattern demonstrated in the beelines-python library ([see here]). This will allow users to define custom sampler hooks that meet a standard interface. This change required refactor of existing deterministic sampler (and its tests) to fit with the new interface requirements.

### What's missing?
1. I haven't added any documentation. Usage docs don't appear to live in this repo.
2. There are no tests for what happens if you do not provide a samplerHook or a sampleRate. See roughly line 224 in `lib/api/libhoney.js` for more detail. I wasn't sure the best way to verify that `send()` was called rather than `sendPresampled()`.

[see here]: https://github.com/honeycombio/beeline-python/blob/master/beeline/__init__.py#L179