### PR TITLE
Parameterise startSpan to accept custom span and parent ids

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -60,8 +60,8 @@ module.exports = {
     }
   },
 
-  startSpan(metadataContext) {
-    return apiImpl.startSpan(metadataContext);
+  startSpan(metadataContext, spanId = undefined, parentId = undefined) {
+    return apiImpl.startSpan(metadataContext, spanId, parentId);
   },
   finishSpan(span, rollupKey) {
     return apiImpl.finishSpan(span, rollupKey);

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -66,6 +66,63 @@ test("startTrace starts tracking and creates an initial event, finishTrace sends
   expect(postData[schema.DURATION_MS]).not.toBeUndefined();
 });
 
+describe("startTrace", () => {
+  test("correctly initialises event with default parameters", () => {
+    event._resetForTesting();
+    event.configure({
+      impl: "libhoney-event",
+      transmission: "mock",
+      writeKey: "abc123",
+    });
+    event.startTrace();
+    const eventPayload = event.startSpan();
+
+    expect(eventPayload).not.toBe(null);
+
+    expect(eventPayload.startTime).toBeDefined();
+    expect(eventPayload.startTimeHR).toBeDefined();
+    expect(eventPayload[schema.TRACE_ID]).toBeDefined();
+    expect(eventPayload[schema.TRACE_PARENT_ID]).toBeDefined();
+    expect(eventPayload[schema.TRACE_SPAN_ID]).toBeDefined();
+  });
+
+  test("can override span_id if required", () => {
+    event._resetForTesting();
+    event.configure({
+      impl: "libhoney-event",
+      transmission: "mock",
+      writeKey: "abc123",
+    });
+    event.startTrace();
+    const eventPayload = event.startSpan({}, "myUniqueSpanIdGenerationMethod");
+
+    expect(eventPayload[schema.TRACE_SPAN_ID]).toEqual("myUniqueSpanIdGenerationMethod");
+  });
+
+  test("can override parent_id if required", () => {
+    event._resetForTesting();
+    event.configure({
+      impl: "libhoney-event",
+      transmission: "mock",
+      writeKey: "abc123",
+    });
+    event.startTrace();
+    const parentEvent = event.startSpan();
+
+    // Initialise another event that we don't want our childEvent to be a child
+    // of. This out of order behaviour can happen when the lifecycle of a span
+    // and its children are asyncronously processed, such as GraphQL resolving
+    // fields within an object. When this happens we want to manage the
+    // parent-child relationship manually, thus requiring this API to be
+    // available.
+    event.startSpan();
+
+    const childEvent = event.startSpan({}, undefined, parentEvent[schema.TRACE_SPAN_ID]);
+
+    expect(childEvent[schema.TRACE_PARENT_ID]).toEqual(parentEvent[schema.TRACE_SPAN_ID]);
+  });
+});
+
 test("sample rates are propagated", () => {
   event._resetForTesting();
   event.configure({

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -106,10 +106,9 @@ module.exports = class LibhoneyEventAPI {
   startSpan(metadataContext, spanId = uuidv4(), parentId = undefined) {
     let context = tracker.getTracked();
     if (context.stack.length > 0) {
-      if (parentId) {
-        debug("parentId supplied when there are already spans.. wrong.");
+      if (parentId === undefined) {
+        parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
       }
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
     }
     const eventPayload = Object.assign({}, metadataContext, {
       [schema.TRACE_ID]: context.id,


### PR DESCRIPTION
While developing an Apollo Server extension to trace the resolving of fields in a GraphQL query, it became necessary to be able to modify a new span’s parent due to the asynchronous nature of these resolvers.