### PR TITLE
Wrap Bluebird _then method, all promise fns go through here

### DIFF
--- a/lib/instrumentation/bluebird.js
+++ b/lib/instrumentation/bluebird.js
@@ -6,16 +6,11 @@ const shimmer = require("shimmer"),
 // propagation makes it through the various Promise callbacks.
 
 let instrumentBluebird = Promise => {
-  shimmer.wrap(Promise.prototype, "then", function(original) {
-    return function then(onFulfilled, onRejected) {
-      let args = [];
-      if (arguments.length > 0) {
-        args.push(api.bindFunctionToTrace(onFulfilled));
-      }
-      if (arguments.length > 1) {
-        args.push(api.bindFunctionToTrace(onRejected));
-      }
-      return original.apply(this, args);
+  shimmer.wrap(Promise.prototype, "_then", function(original) {
+    return function _then(didFulfill, didReject, _, receiver, internalData) {
+      const onFulfilled = typeof didFulfill === 'function' ? api.bindFunctionToTrace(didFulfill) : didFulfill
+      const onRejected = typeof didReject === 'function' ? api.bindFunctionToTrace(didReject) : didReject
+      return original.call(this, onFulfilled, onRejected, _, receiver, internalData);
     };
   });
   return Promise;


### PR DESCRIPTION
When using Bluebird, all promise helpers / methods (`.map`, `.race`, `.tap`, `.reflect`, etc.) are passed through an internal [`_then` method](https://github.com/petkaantonov/bluebird/blob/49da1ac256c7ee0fb1e07679791399f24648b933/src/promise.js#L220-L277). This PR wraps that `_then` rather than the top level `then` to ensure the trace fns are bound when called from these helpers.