### PR TITLE
first pass of promise-mysql instrumentation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Chris Toshok
 Christine Yen
 Erwin van der Koogh
 Ally Weir
+Michael Nagy

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -11,6 +11,7 @@ const instrumentations = [
   "express",
   "react-dom/server",
   "mysql2",
+  "promise-mysql",
   "http",
   "https",
   "mongodb",

--- a/lib/instrumentation/promise-mysql.js
+++ b/lib/instrumentation/promise-mysql.js
@@ -1,0 +1,85 @@
+/* eslint-env node */
+const shimmer = require("shimmer");
+const api = require("../api");
+const schema = require("../schema");
+
+function instrumentConnection(connection, packageVersion) {
+  shimmer.wrap(connection, "query", function(original) {
+    return function(...args) {
+      if (!api.traceActive()) {
+        return original.apply(this, args);
+      }
+
+      return api.startAsyncSpan(
+        {
+          [schema.EVENT_TYPE]: "mysql",
+          [schema.PACKAGE_VERSION]: packageVersion,
+          [schema.TRACE_SPAN_NAME]: "query",
+          "db.query": args[0],
+          "db.binds": args[1] || [],
+        },
+        span => {
+          const returnValue = original.apply(this, args);
+
+          returnValue
+            .then(() => {
+              api.finishSpan(span);
+            })
+            .catch(err => {
+              if (err) {
+                api.addContext({ error: err.toString() });
+              }
+
+              api.finishSpan(span);
+            });
+
+          return returnValue;
+        }
+      );
+    };
+  });
+
+  return connection;
+}
+
+function instrumentPool(pool, packageVersion) {
+  shimmer.wrap(pool, "getConnection", function(original) {
+    return function(...args) {
+      let connection = original.apply(this, args);
+
+      connection.then(connection => {
+        instrumentConnection(connection, packageVersion);
+      });
+
+      return connection;
+    };
+  });
+
+  return pool;
+}
+
+function instrumentPromiseMysql(mysql, opts = {}) {
+  shimmer.wrap(mysql, "createPool", function(original) {
+    return function(...args) {
+      let pool = original.apply(this, args);
+
+      return instrumentPool(pool, opts.packageVersion);
+    };
+  });
+
+  shimmer.wrap(mysql, "createConnection", function(original) {
+    return function(...args) {
+      let connection = original.apply(this, args);
+
+      connection.then(connection => {
+        instrumentConnection(connection, opts.packageVersion);
+      });
+
+      return connection;
+    };
+  });
+
+  return mysql;
+}
+
+module.exports = instrumentPromiseMysql;


### PR DESCRIPTION
Without completely mocking `promise-mysql`, I'm not sure if there's a great way to unit test this. I didn't see any other good examples of db unit tests for the other instrumentations, so I'm submitting as is, but happy to explore unit tests for mocking `promise-mysql`.