### PR TITLE
fix update function calls to use fourArgs

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -112,69 +112,57 @@ function instrumentMongodb(mongodb, opts = {}) {
   wrap("insertOne", threeArgs, document => (opts.includeDocuments ? { document } : {}));
 
   // @return {Promise} returns Promise if no callback passed
-  wrap(
-    "insertMany",
-    threeArgs,
-    documents =>
-      opts.includeDocuments
-        ? {
-            documents,
-            documents_count: documents.length,
-          }
-        : {}
+  wrap("insertMany", threeArgs, documents =>
+    opts.includeDocuments
+      ? {
+          documents,
+          documents_count: documents.length,
+        }
+      : {}
   );
   // * @return {Promise} returns Promise if no callback passed
-  wrap(
-    "bulkWrite",
-    threeArgs,
-    operations =>
-      opts.includeDocuments && Array.isArray(operations)
-        ? {
-            operations,
-            operations_count: operations.length,
-          }
-        : {}
+  wrap("bulkWrite", threeArgs, operations =>
+    opts.includeDocuments && Array.isArray(operations)
+      ? {
+          operations,
+          operations_count: operations.length,
+        }
+      : {}
   );
   // .insert is just a wrapper around .insertMany
 
   // * @return {Promise} returns Promise if no callback passed
-  wrap("updateOne", threeArgs, (filter, update) => ({
+  wrap("updateOne", fourArgs, (filter, update) => ({
     filter,
     update,
   }));
 
   // * @return {Promise} returns Promise if no callback passed
-  wrap(
-    "replaceOne",
-    threeArgs,
-    (filter, document) =>
-      opts.includeDocuments
-        ? {
-            filter,
-            document,
-          }
-        : {
-            filter,
-          }
+  wrap("replaceOne", fourArgs, (filter, document) =>
+    opts.includeDocuments
+      ? {
+          filter,
+          document,
+        }
+      : {
+          filter,
+        }
   );
   // * @return {Promise} returns Promise if no callback passed
-  wrap("updateMany", threeArgs, (filter, update) => ({
+  wrap("updateMany", fourArgs, (filter, update) => ({
     filter,
     update,
   }));
   // * @return {Promise} returns Promise if no callback passed
-  wrap(
-    "update",
-    threeArgs,
-    (selector, document) =>
-      opts.includeDocuments
-        ? {
-            selector,
-            document,
-          }
-        : {
-            selector,
-          }
+  wrap("update", fourArgs, (selector, document) =>
+    opts.includeDocuments
+      ? {
+          selector,
+          document,
+        }
+      : {
+          selector,
+        }
   );
 
   // * @return {Promise} returns Promise if no callback passed


### PR DESCRIPTION
`replaceOne`, `update`, `updateOne` and `updateMany` take four arguments, not three - refer to https://mongodb.github.io/node-mongodb-native/3.2/api/Collection.html#update for example.

As is, using three arguments + promise method (no callback) results in ...

```
TypeError: callback is not a function
.../node_modules/honeycomb-beeline/lib/instrumentation/mongodb.js:59:24
```