### PR TITLE
[mongodb] handle null options

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -5,9 +5,11 @@ const shimmer = require("shimmer"),
 
 function prefixKeys(prefix, map) {
   let prefixed = {};
-  Object.keys(map).forEach(k => {
-    prefixed[`${prefix}.${k}`] = map[k];
-  });
+  if (map) {
+    Object.keys(map).forEach(k => {
+      prefixed[`${prefix}.${k}`] = map[k];
+    });
+  }
   return prefixed;
 }
 

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -3,7 +3,7 @@ const shimmer = require("shimmer"),
   api = require("../api"),
   schema = require("../schema");
 
-function prefixKeys(prefix, map = {}) {
+function prefixKeys(prefix, map) {
   let prefixed = {};
   Object.keys(map).forEach(k => {
     prefixed[`${prefix}.${k}`] = map[k];

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -48,7 +48,9 @@ function instrumentMongodb(mongodb, opts = {}) {
             [schema.TRACE_SPAN_NAME]: eventName,
           },
           span => {
-            api.addContext(prefixKeys("db.options", options));
+            if (options) {
+              api.addContext(prefixKeys("db.options", options));
+            }
             if (additionalContext) {
               api.addContext(prefixKeys("db", additionalContext(...populatedArgs)));
             }


### PR DESCRIPTION
Fixes #136 

Change `prefixKeys` from defaulting the `map` parameter to `{}` (which only works when the argument is `undefined`) and instead guard around the `addContext("db.options", options)` call.

This means that `additionalContext` callbacks _must_ return an object if present (which they all do).