### PR TITLE
Fix mysql2 query missing in the traces

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Chris Toshok
 Christine Yen
 Erwin van der Koogh
 Ally Weir
+Ashish Bista

--- a/lib/instrumentation/mysql2.js
+++ b/lib/instrumentation/mysql2.js
@@ -4,7 +4,7 @@ const shimmer = require("shimmer"),
   schema = require("../schema");
 
 let instrumentConnection = function(conn, packageVersion) {
-  shimmer.wrap(conn, "execute", function(original) {
+  shimmer.massWrap(conn, ['query', 'execute'], function(original) {
     return function(...args) {
       if (args.length < 1) {
         return original.apply(this, args);
@@ -12,43 +12,16 @@ let instrumentConnection = function(conn, packageVersion) {
       if (!api.traceActive()) {
         return original.apply(this, args);
       }
-
+      query = args[0].sql
+      if (typeof query === 'undefined') {
+        query = args[0]
+      }
       api.startAsyncSpan(
         {
           [schema.EVENT_TYPE]: "mysql2",
           [schema.PACKAGE_VERSION]: packageVersion,
           [schema.TRACE_SPAN_NAME]: "query",
-          "db.query": args[0].sql,
-        },
-        span => {
-          let cb = args[args.length - 1];
-          let wrapped_cb = function(...cb_args) {
-            api.finishSpan(span, "query");
-            return cb(...cb_args);
-          };
-
-          return original.apply(this, args.slice(0, -1).concat(wrapped_cb));
-        }
-      );
-    };
-  });
-
-  shimmer.wrap(conn, "query", function(original) {
-    // this is the same as the execute shim.
-    return function(...args) {
-      if (args.length < 1) {
-        return original.apply(this, args);
-      }
-      if (!api.traceActive()) {
-        return original.apply(this, args);
-      }
-
-      api.startAsyncSpan(
-        {
-          [schema.EVENT_TYPE]: "mysql2",
-          [schema.PACKAGE_VERSION]: packageVersion,
-          [schema.TRACE_SPAN_NAME]: "query",
-          "db.query": args[0].sql,
+          "db.query": query,
         },
         span => {
           let cb = args[args.length - 1];
@@ -64,6 +37,7 @@ let instrumentConnection = function(conn, packageVersion) {
       );
     };
   });
+
   return conn;
 };
 


### PR DESCRIPTION
Before this, mysql2 was not including the real database queries in the trace body.

I also used this opportunity to DRY out the code a bit using `shimmer.massWrap` replacing two instances of `shimmer.wrap`.

To reproduce the current issue:

```
# cat index.js

const beeline =  require("honeycomb-beeline")({
 writeKey: "xxxxxxxxxxxxxxxxxx",
 dataset: "xxxxxxxxxxxxx",
 serviceName: "my-awesome-service"
});

const express = require('express')
const app = express()
const port = 3000

const mysql = require('mysql2');

// create the connection to database
const connection = mysql.createConnection({
  host: 'localhost',
  user: 'root',
  password: 'xxxxxx',
  database: 'my_awesome_service_development'
});

app.get('/', (req, res) => {
  console.log("Get /");
  connection.query(
    'SELECT * FROM `posts` WHERE `title` = "a"',
    function(err, results, fields) {
    }
  );

  connection.execute(
    'SELECT * FROM `posts`',
    function(err, results, fields) {
    }
  );

  res.send('Hello from my super simple service!');
})

app.listen(port, () => console.log(`Listening on port ${port}!`))

```

```
# cat package.json

{
  "name": "my-awesome-service",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "dependencies": {
    "express": "^4.17.1",
    "honeycomb-beeline": "^1.5.1",
    "mysql2": "^1.6.5"
  },
  "devDependencies": {},
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC"
}

```

When you run above sample application, you would see mysql queries missing the traces.

I didn't write tests for my commit because I don't see any tests written for mysql2.js.