### PR TITLE
Add support for mysql2#createPool

### DIFF
--- a/lib/instrumentation/mysql2.js
+++ b/lib/instrumentation/mysql2.js
@@ -3,49 +3,42 @@ const shimmer = require("shimmer"),
   api = require("../api"),
   schema = require("../schema");
 
-let instrumentConnection = function(conn, packageVersion) {
-  shimmer.massWrap(conn, ['query', 'execute'], function(original) {
+let instrumentMysql2 = function(mysql2, opts = {}) {
+  shimmer.massWrap(mysql2.Connection.prototype, ["execute", "query"], function(original) {
     return function(...args) {
-      if (args.length < 1) {
+      if (args.length < 1 || !api.traceActive()) {
         return original.apply(this, args);
       }
-      if (!api.traceActive()) {
-        return original.apply(this, args);
+
+      query = args[0].sql;
+      if (typeof query === "undefined") {
+        query = args[0];
       }
-      query = args[0].sql
-      if (typeof query === 'undefined') {
-        query = args[0]
-      }
-      api.startAsyncSpan(
+      return api.startAsyncSpan(
         {
           [schema.EVENT_TYPE]: "mysql2",
-          [schema.PACKAGE_VERSION]: packageVersion,
+          [schema.PACKAGE_VERSION]: opts.packageVersion,
           [schema.TRACE_SPAN_NAME]: "query",
           "db.query": query,
         },
         span => {
-          let cb = args[args.length - 1];
+          let callback = args[args.length - 1];
           // XXX(toshok) this bindFunction shouldn't be necessary, but we aren't
           // finishing the event properly without it.
-          let wrapped_cb = api.bindFunctionToTrace(function(...cb_args) {
+          if (callback && typeof callback === "function") {
+            let wrapped_callback = api.bindFunctionToTrace(function(...callback_args) {
+              api.finishSpan(span, "query");
+              return callback(...callback_args);
+            });
+            return original.apply(this, args.slice(0, -1).concat(wrapped_callback));
+          }
+          try {
+            return original.apply(this, args);
+          } finally {
             api.finishSpan(span, "query");
-            return cb(...cb_args);
-          });
-
-          return original.apply(this, args.slice(0, -1).concat(wrapped_cb));
+          }
         }
       );
-    };
-  });
-
-  return conn;
-};
-
-let instrumentMysql2 = function(mysql2, opts = {}) {
-  shimmer.wrap(mysql2, "createConnection", function(original) {
-    return function(...args) {
-      let conn = original.apply(this, args);
-      return instrumentConnection(conn, opts.packageVersion);
     };
   });
   return mysql2;


### PR DESCRIPTION
Before this, you wouldn’t get mysql queries in the traces if you were using `mysql2#createPool` instead of `mysql2#createConnection`. This commit adds support for `mysql2#createPool`.

More on mysql2#createPool: https://github.com/sidorares/node-mysql2#using-connection-pools

The following sample app can be used to test it:

```
# Schema
CREATE TABLE `posts` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `title` varchar(255) DEFAULT NULL,
  `body` text,
  `created_at` datetime NOT NULL,
  `updated_at` datetime NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8;
```

```
const beeline =  require("honeycomb-beeline")({
 writeKey: “xxxxxxxx”,
 dataset: “xxxxxx”,
 serviceName: "my-awesome-service"
});

const express = require('express')
const app = express()
const port = 3000

const mysql = require('mysql2');

const connection = mysql.createConnection({
  host: 'localhost',
  user: 'root',
  password: ‘xxxxx’,
  database: 'awesome_development'
});

const pool = mysql.createPool({
  host: '127.0.0.1',
  user: 'root',
  password: ‘xxxxx’,
  database: 'awesome_development'
});

app.get('/', (req, res) => {
  pool.query(
    'SELECT * FROM `posts` WHERE `title` = "pool.query"',
    function(err, results, fields) {
    }
  );

  pool.execute(
    'SELECT * FROM `posts` WHERE `title` = "pool.execute"',
    function(err, results, fields) {
    }
  );

  connection.query(
    'SELECT * FROM `posts` WHERE `title` = "connection.query"',
    function(err, results, fields) {
    }
  );

  connection.execute(
    'SELECT * FROM `posts` WHERE `title` = "connection.execute"',
    function(err, results, fields) {
    }
  );

  pool.getConnection(function(err, poolConnection1) {
    poolConnection1.query(
      'SELECT * FROM `posts` WHERE `title` = "poolConnection1.query"',
      function(err, results, fields) {
      }
    );
  });

  pool.getConnection(function(err, poolConnection1) {
    poolConnection1.execute(
      'SELECT * FROM `posts` WHERE `title` = "poolConnection2.execute"',
      function(err, results, fields) {
      }
    );
  });

  pool.getConnection(function(err, poolConnection2) {
    poolConnection2.query(
      'SELECT * FROM `posts` WHERE `title` = "poolConnection2.query"',
      function(err, results, fields) {
      }
    );
  });
  pool.getConnection(function(err, poolConnection2) {
    poolConnection2.execute(
      'SELECT * FROM `posts` WHERE `title` = "poolConnection2.execute"',
      function(err, results, fields) {
      }
    );
  });

  res.send({});
})

```