### PR TITLE
initial fastify instrumentation

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -8,17 +8,18 @@ const shimmer = require("shimmer"),
   debug = require("debug")(`${pkg.name}:instrumentation`);
 
 const instrumentations = [
+  "bluebird",
+  "child_process",
   "express",
-  "react-dom/server",
-  "mysql2",
+  "fastify",
   "http",
   "https",
   "mongodb",
   "mongoose",
   "mpromise",
-  "bluebird",
+  "mysql2",
+  "react-dom/server",
   "sequelize",
-  "child_process",
 ];
 
 let enabledInstrumentations = new Set(instrumentations);

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -6,9 +6,9 @@ const onHeaders = require("on-headers"),
   schema = require("../schema"),
   api = require("../api"),
   util = require("../util"),
+  traceUtil = require("./trace-util"),
   path = require("path"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
-  traceUtil = require("trace-util"),
   debug = require("debug")(`${pkg.name}:express`);
 
 const slice = Array.prototype.slice;
@@ -79,7 +79,7 @@ function wrapErrMiddleware(middleware, debugWrap) {
 }
 
 const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (req, res, next) => {
-  let traceContext = traceUtil.getTraceContext(traceIdSource, req);
+  let traceContext = traceUtil.getTraceContext(traceIdSource, req.headers);
   let trace = api.startTrace(
     {
       [schema.EVENT_TYPE]: "express",

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -79,7 +79,7 @@ function wrapErrMiddleware(middleware, debugWrap) {
 }
 
 const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (req, res, next) => {
-  let traceContext = traceUtil.getTraceContext(traceIdSource, req.headers);
+  let traceContext = traceUtil.getTraceContext(traceIdSource, req);
   let trace = api.startTrace(
     {
       [schema.EVENT_TYPE]: "express",

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -8,100 +8,10 @@ const onHeaders = require("on-headers"),
   util = require("../util"),
   path = require("path"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
+  traceUtil = require("trace-util"),
   debug = require("debug")(`${pkg.name}:express`);
 
 const slice = Array.prototype.slice;
-
-// returns the header name/value for the first header with a value in the request.
-const getValueFromHeaders = (req, headers) => {
-  let value, header;
-
-  for (const h of headers) {
-    let headerValue = req.get(h);
-    if (headerValue) {
-      header = h; // source = `${h} http header`;
-      value = headerValue;
-      break;
-    }
-  }
-
-  if (typeof value !== "undefined") {
-    return { value, header };
-  }
-
-  return undefined;
-};
-
-const getTraceContext = (traceIdSource, req) => {
-  if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
-    let headers =
-      typeof traceIdSource === "undefined"
-        ? [api.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
-        : [traceIdSource];
-    let valueAndHeader = getValueFromHeaders(req, headers);
-
-    if (!valueAndHeader) {
-      return {};
-    }
-    let { value, header } = valueAndHeader;
-
-    switch (header) {
-      case api.TRACE_HTTP_HEADER: {
-        let parsed = api.unmarshalTraceContext(value);
-        if (!parsed) {
-          return {};
-        }
-        return Object.assign({}, parsed, {
-          source: `${header} http header`,
-        });
-      }
-
-      default: {
-        return {
-          traceId: value,
-          source: `${header} http header`,
-        };
-      }
-    }
-  } else {
-    return {
-      traceId: traceIdSource(req),
-      source: "traceIdSource function",
-    };
-  }
-};
-
-const getUserContext = (userContext, req) => {
-  if (!userContext) {
-    return undefined;
-  }
-
-  // if we've got user data (from some other middleware), add it to the events
-  let keys;
-  let userObject;
-
-  if (Array.isArray(userContext) && req.user) {
-    keys = userContext;
-    userObject = req.user;
-  } else if (typeof userContext === "function") {
-    userObject = userContext(req);
-    keys = userObject && Object.keys(userObject);
-  }
-
-  if (!userObject) {
-    return undefined;
-  }
-
-  const userEventContext = {};
-
-  for (const k of keys) {
-    const v = userObject[k];
-    if (typeof v !== "function") {
-      userEventContext[`request.user.${k}`] = v;
-    }
-  }
-  return userEventContext;
-};
 
 function wrapNextMiddleware(middleware, debugWrap) {
   let debugLocation;
@@ -169,7 +79,7 @@ function wrapErrMiddleware(middleware, debugWrap) {
 }
 
 const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (req, res, next) => {
-  let traceContext = getTraceContext(traceIdSource, req);
+  let traceContext = traceUtil.getTraceContext(traceIdSource, req);
   let trace = api.startTrace(
     {
       [schema.EVENT_TYPE]: "express",
@@ -213,7 +123,7 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
       api._askForIssue("we lost our tracking somewhere in the stack handling this request", debug);
     }
 
-    let userEventContext = getUserContext(userContext, req);
+    let userEventContext = traceUtil.getUserContext(userContext, req);
     if (userEventContext) {
       api.addContext(userEventContext);
     }

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -1,0 +1,36 @@
+/* eslint-env node */
+// const onHeaders = require("on-headers"),
+// shimmer = require("shimmer"),
+// flatten = require("array-flatten"),
+// tracker = require("../async_tracker"),
+// schema = require("../schema"),
+// api = require("../api"),
+// util = require("../util"),
+// path = require("path"),
+// pkg = require(path.join(__dirname, "..", "..", "package.json")),
+// traceUtil = require("trace-util"),
+// debug = require("debug")(`${pkg.name}:fastify`);
+
+let instrumentFastify = function(fastify, _opts = {}) {
+  // let userContext, traceIdSource;
+  // if (opts.userContext) {
+  //   if (Array.isArray(opts.userContext) || typeof opts.userContext === "function") {
+  //     userContext = opts.userContext;
+  //   } else {
+  //     debug(
+  //       "userContext option must either be an array of field names or a function returning an object"
+  //     );
+  //   }
+  // }
+  // if (opts.traceIdSource) {
+  //   if (typeof opts.traceIdSource === "string" || typeof opts.traceIdSource === "function") {
+  //     traceIdSource = opts.traceIdSource;
+  //   } else {
+  //     debug(
+  //       "traceIdSource option must either be an string (the http header name) or a function returning the string request id"
+  //     );
+  //   }
+  // }
+};
+
+module.exports = instrumentFastify;

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -43,8 +43,6 @@ const instrumentFastify = function(fastify, opts = {}) {
 
     app.addHook("onRequest", (request, reply, next) => {
       // start our trace handling
-      debug("in onRequest");
-
       let traceContext = traceUtil.getTraceContext(traceIdSource, request);
       let trace = api.startTrace(
         {
@@ -103,11 +101,8 @@ const instrumentFastify = function(fastify, opts = {}) {
 
     app.addHook("onResponse", (request, reply, next) => {
       // calculate total time for the request and send the root span
-      debug("in onResponse");
-
       const finisher = finishersByRequest.get(request);
       if (finisher) {
-        debug("finishing");
         finisher(reply);
       }
 

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -124,35 +124,50 @@ const instrumentFastify = function(fastify, opts = {}) {
     shimmer.wrap(app, "addHook", function instrumentAddHook(original) {
       return function(hookName, hookFn) {
         if (hookName == "onResponse") {
+          // we need to skip onResponse hooks, because we will have already ended the
+          // trace.  we need a way to manipulate onResponse hooks
           return original.apply(this, [hookName, hookFn]);
         }
 
-        let wrappedHook;
-        if (isPromise(hookFn)) {
-          throw new Error("ugh");
-        } else {
-          wrappedHook = function(...args) {
-            let request = args[0];
+        let wrappedHook = function(...args) {
+          let request = args[0];
 
-            let tracked = trackedByRequest.get(request);
-            tracker.setTracked(tracked);
+          let tracked = trackedByRequest.get(request);
+          tracker.setTracked(tracked);
 
-            let span = api.startSpan({
-              name: `${hookName} hook`,
-              // XXX toshok more here
-            });
-            let next = args[args.length - 1];
+          let span = api.startSpan({
+            name: `${hookName} hook`,
+            // XXX toshok more here
+          });
+          let next = args[args.length - 1];
+          let wrappedNext;
 
-            if (typeof next != "function") {
-              console.error(`next isn't a function in ${hookName} hook`);
-            }
-            let wrappedNext = function() {
+          if (next && typeof next === "function") {
+            wrappedNext = function() {
               api.finishSpan(span);
               return next();
             };
-            return hookFn.apply(this, slice.call(args, 0, -1).concat([wrappedNext]));
-          };
-        }
+            args = slice.call(args, 0, -1).concat([wrappedNext]);
+          }
+
+          let rv = hookFn.apply(this, args);
+          if (!isPromise(rv)) {
+            // we don't end the span here - it should be ended with the call to next()
+            return rv;
+          }
+
+          return new Promise((resolve, reject) => {
+            rv.then(v => {
+              tracker.setTracked(tracked);
+              api.finishSpan(span);
+              resolve(v);
+            }).catch(e => {
+              tracker.setTracked(tracked);
+              api.finishSpan(span);
+              reject(e);
+            });
+          });
+        };
 
         return original.apply(this, [hookName, wrappedHook]);
       };

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -110,6 +110,7 @@ const instrumentFastify = function(fastify, opts = {}) {
     });
 
     // now that we've added our special hooks, instrument the addHook method such that
+    // others will show up as spans in the trace.
     shimmer.wrap(app, "addHook", function instrumentAddHook(original) {
       return function(hookName, hookFn) {
         if (hookName == "onResponse") {
@@ -128,7 +129,6 @@ const instrumentFastify = function(fastify, opts = {}) {
             name: `${hookName} hook`,
             [schema.EVENT_TYPE]: "fastify",
             [schema.PACKAGE_VERSION]: opts.packageVersion,
-            // XXX toshok more here
           });
           let next = args[args.length - 1];
           let wrappedNext;
@@ -177,7 +177,6 @@ const instrumentFastify = function(fastify, opts = {}) {
             name: `handler: ${method} ${handlerUrl}`,
             [schema.EVENT_TYPE]: "fastify",
             [schema.PACKAGE_VERSION]: opts.packageVersion,
-            // XXX toshok more here
           });
 
           let rv = fn.apply(this, [request, reply]);

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -53,18 +53,12 @@ const instrumentFastify = function(fastify, opts = {}) {
           [schema.TRACE_SPAN_NAME]: "request",
           [schema.TRACE_ID_SOURCE]: traceContext.source,
           "request.host": request.hostname,
-          "request.base_url": request.baseUrl,
-          "request.original_url": request.originalUrl,
+          "request.original_url": request.req.originalUrl,
           "request.remote_addr": request.ip,
-          "request.secure": request.secure,
-          "request.method": request.method,
+          "request.method": request.req.method,
           "request.route": request.route ? request.route.path : undefined,
-          "request.scheme": request.protocol,
-          "request.path": request.path,
           "request.query": request.query,
           "request.http_version": `HTTP/${request.req.httpVersion}`,
-          "request.fresh": request.fresh,
-          "request.xhr": request.xhr,
         },
         traceContext.traceId,
         traceContext.parentSpanId,
@@ -137,6 +131,8 @@ const instrumentFastify = function(fastify, opts = {}) {
 
           let span = api.startSpan({
             name: `${hookName} hook`,
+            [schema.EVENT_TYPE]: "fastify",
+            [schema.PACKAGE_VERSION]: opts.packageVersion,
             // XXX toshok more here
           });
           let next = args[args.length - 1];
@@ -173,23 +169,19 @@ const instrumentFastify = function(fastify, opts = {}) {
       };
     });
 
-    shimmer.wrap(app, "delete", function instrumentDelete(original) {
-      return function(url, opts, handler) {
-        // TODO wrap the handler
-        return original.apply(this, [url, opts, handler]);
-      };
-    });
-
-    shimmer.wrap(app, "get", function instrumentGet(original) {
-      return function(url, opts, handler) {
-        let fn = isPromise(opts) || typeof opts === "function" ? opts : handler;
+    function instrumentRoute(method, original) {
+      return function(handlerUrl, handlerOpts, handlerFn) {
+        let fn =
+          isPromise(handlerOpts) || typeof handlerOpts === "function" ? handlerOpts : handlerFn;
 
         let wrappedHandler = function(request, reply) {
           let tracked = trackedByRequest.get(request);
           tracker.setTracked(tracked);
 
           let span = api.startSpan({
-            name: `handler: GET ${url}`,
+            name: `handler: ${method} ${handlerUrl}`,
+            [schema.EVENT_TYPE]: "fastify",
+            [schema.PACKAGE_VERSION]: opts.packageVersion,
             // XXX toshok more here
           });
 
@@ -213,49 +205,16 @@ const instrumentFastify = function(fastify, opts = {}) {
         };
         return original.apply(this, slice.call(arguments, 0, -1).concat([wrappedHandler]));
       };
-    });
+    }
 
-    shimmer.wrap(app, "head", function instrumentHead(original) {
-      return function(url, opts, handler) {
-        // TODO wrap the handler
-        return original.apply(this, [url, opts, handler]);
-      };
-    });
-
-    shimmer.wrap(app, "patch", function instrumentPatch(original) {
-      return function(url, opts, handler) {
-        // TODO wrap the handler
-        return original.apply(this, [url, opts, handler]);
-      };
-    });
-
-    shimmer.wrap(app, "post", function instrumentPost(original) {
-      return function(url, opts, handler) {
-        // TODO wrap the handler
-        return original.apply(this, [url, opts, handler]);
-      };
-    });
-
-    shimmer.wrap(app, "put", function instrumentPut(original) {
-      return function(url, opts, handler) {
-        // TODO wrap the handler
-        return original.apply(this, [url, opts, handler]);
-      };
-    });
-
-    shimmer.wrap(app, "options", function instrumentOptions(original) {
-      return function(url, opts, handler) {
-        // TODO wrap the handler
-        return original.apply(this, [url, opts, handler]);
-      };
-    });
-
-    shimmer.wrap(app, "all", function instrumentAll(original) {
-      return function(url, opts, handler) {
-        // TODO wrap the handler
-        return original.apply(this, [url, opts, handler]);
-      };
-    });
+    shimmer.wrap(app, "delete", original => instrumentRoute("DELETE", original));
+    shimmer.wrap(app, "get", original => instrumentRoute("GET", original));
+    shimmer.wrap(app, "head", original => instrumentRoute("GET", original));
+    shimmer.wrap(app, "patch", original => instrumentRoute("PATCH", original));
+    shimmer.wrap(app, "post", original => instrumentRoute("POST", original));
+    shimmer.wrap(app, "put", original => instrumentRoute("PUT", original));
+    shimmer.wrap(app, "options", original => instrumentRoute("OPTIONS", original));
+    shimmer.wrap(app, "all", original => instrumentRoute("ALL", original));
 
     return app;
   };

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -62,7 +62,7 @@ const instrumentFastify = function(fastify, opts = {}) {
           "request.scheme": request.protocol,
           "request.path": request.path,
           "request.query": request.query,
-          "request.http_version": `HTTP/${request.httpVersion}`,
+          "request.http_version": `HTTP/${request.req.httpVersion}`,
           "request.fresh": request.fresh,
           "request.xhr": request.xhr,
         },

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -1,36 +1,254 @@
 /* eslint-env node */
-// const onHeaders = require("on-headers"),
-// shimmer = require("shimmer"),
-// flatten = require("array-flatten"),
-// tracker = require("../async_tracker"),
-// schema = require("../schema"),
-// api = require("../api"),
-// util = require("../util"),
-// path = require("path"),
-// pkg = require(path.join(__dirname, "..", "..", "package.json")),
-// traceUtil = require("trace-util"),
-// debug = require("debug")(`${pkg.name}:fastify`);
+const shimmer = require("shimmer"),
+  tracker = require("../async_tracker"),
+  schema = require("../schema"),
+  api = require("../api"),
+  traceUtil = require("./trace-util"),
+  path = require("path"),
+  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+  debug = require("debug")(`${pkg.name}:fastify`);
 
-let instrumentFastify = function(fastify, _opts = {}) {
-  // let userContext, traceIdSource;
-  // if (opts.userContext) {
-  //   if (Array.isArray(opts.userContext) || typeof opts.userContext === "function") {
-  //     userContext = opts.userContext;
-  //   } else {
-  //     debug(
-  //       "userContext option must either be an array of field names or a function returning an object"
-  //     );
-  //   }
-  // }
-  // if (opts.traceIdSource) {
-  //   if (typeof opts.traceIdSource === "string" || typeof opts.traceIdSource === "function") {
-  //     traceIdSource = opts.traceIdSource;
-  //   } else {
-  //     debug(
-  //       "traceIdSource option must either be an string (the http header name) or a function returning the string request id"
-  //     );
-  //   }
-  // }
+const slice = Array.prototype.slice;
+
+function isPromise(p) {
+  return p && typeof p.then !== "undefined";
+}
+
+const instrumentFastify = function(fastify, opts = {}) {
+  let userContext, traceIdSource;
+  if (opts.userContext) {
+    if (Array.isArray(opts.userContext) || typeof opts.userContext === "function") {
+      userContext = opts.userContext;
+    } else {
+      debug(
+        "userContext option must either be an array of field names or a function returning an object"
+      );
+    }
+  }
+  if (opts.traceIdSource) {
+    if (typeof opts.traceIdSource === "string" || typeof opts.traceIdSource === "function") {
+      traceIdSource = opts.traceIdSource;
+    } else {
+      debug(
+        "traceIdSource option must either be an string (the http header name) or a function returning the string request id"
+      );
+    }
+  }
+
+  const trackedByRequest = new Map();
+  const finishersByRequest = new Map();
+
+  const wrapper = function(...args) {
+    const app = fastify(...args);
+
+    app.addHook("onRequest", (request, reply, next) => {
+      // start our trace handling
+      debug("in onRequest");
+
+      let traceContext = traceUtil.getTraceContext(traceIdSource, request);
+      let trace = api.startTrace(
+        {
+          [schema.EVENT_TYPE]: "fastify",
+          [schema.PACKAGE_VERSION]: opts.packageVersion,
+          [schema.TRACE_SPAN_NAME]: "request",
+          [schema.TRACE_ID_SOURCE]: traceContext.source,
+          "request.host": request.hostname,
+          "request.base_url": request.baseUrl,
+          "request.original_url": request.originalUrl,
+          "request.remote_addr": request.ip,
+          "request.secure": request.secure,
+          "request.method": request.method,
+          "request.route": request.route ? request.route.path : undefined,
+          "request.scheme": request.protocol,
+          "request.path": request.path,
+          "request.query": request.query,
+          "request.http_version": `HTTP/${request.httpVersion}`,
+          "request.fresh": request.fresh,
+          "request.xhr": request.xhr,
+        },
+        traceContext.traceId,
+        traceContext.parentSpanId,
+        traceContext.dataset
+      );
+
+      if (traceContext.customContext) {
+        api.addContext(traceContext.customContext);
+      }
+
+      if (!trace) {
+        // sampler has decided that we shouldn't trace this request
+        next();
+        return;
+      }
+
+      const boundFinisher = api.bindFunctionToTrace(reply => {
+        let userEventContext = traceUtil.getUserContext(userContext, request);
+        if (userEventContext) {
+          api.addContext(userEventContext);
+        }
+
+        api.addContext({
+          "response.status_code": String(reply.res.statusCode),
+        });
+        if (request.params) {
+          Object.keys(request.params).forEach(param =>
+            api.addContext({
+              [`request.param.${param}`]: request.params[param],
+            })
+          );
+        }
+
+        api.finishTrace(trace);
+      });
+
+      finishersByRequest.set(request, boundFinisher);
+      trackedByRequest.set(request, tracker.getTracked());
+
+      next();
+    });
+
+    app.addHook("onResponse", (request, reply, next) => {
+      // calculate total time for the request and send the root span
+      debug("in onResponse");
+
+      const finisher = finishersByRequest.get(request);
+      if (finisher) {
+        debug("finishing");
+        finisher(reply);
+      }
+
+      next();
+    });
+
+    // now that we've added our special hooks, instrument the addHook method such that
+    shimmer.wrap(app, "addHook", function instrumentAddHook(original) {
+      return function(hookName, hookFn) {
+        if (hookName == "onResponse") {
+          return original.apply(this, [hookName, hookFn]);
+        }
+
+        let wrappedHook;
+        if (isPromise(hookFn)) {
+          throw new Error("ugh");
+        } else {
+          wrappedHook = function(...args) {
+            let request = args[0];
+
+            let tracked = trackedByRequest.get(request);
+            tracker.setTracked(tracked);
+
+            let span = api.startSpan({
+              name: `${hookName} hook`,
+              // XXX toshok more here
+            });
+            let next = args[args.length - 1];
+
+            if (typeof next != "function") {
+              console.error(`next isn't a function in ${hookName} hook`);
+            }
+            let wrappedNext = function() {
+              api.finishSpan(span);
+              return next();
+            };
+            return hookFn.apply(this, slice.call(args, 0, -1).concat([wrappedNext]));
+          };
+        }
+
+        return original.apply(this, [hookName, wrappedHook]);
+      };
+    });
+
+    shimmer.wrap(app, "delete", function instrumentDelete(original) {
+      return function(url, opts, handler) {
+        // TODO wrap the handler
+        return original.apply(this, [url, opts, handler]);
+      };
+    });
+
+    shimmer.wrap(app, "get", function instrumentGet(original) {
+      return function(url, opts, handler) {
+        let fn = isPromise(opts) || typeof opts === "function" ? opts : handler;
+
+        let wrappedHandler = function(request, reply) {
+          let tracked = trackedByRequest.get(request);
+          tracker.setTracked(tracked);
+
+          let span = api.startSpan({
+            name: `handler: GET ${url}`,
+            // XXX toshok more here
+          });
+
+          let rv = fn.apply(this, [request, reply]);
+          if (!isPromise(rv)) {
+            api.finishSpan(span);
+            return rv;
+          }
+
+          return new Promise((resolve, reject) => {
+            rv.then(v => {
+              tracker.setTracked(tracked);
+              api.finishSpan(span);
+              resolve(v);
+            }).catch(e => {
+              tracker.setTracked(tracked);
+              api.finishSpan(span);
+              reject(e);
+            });
+          });
+        };
+        return original.apply(this, slice.call(arguments, 0, -1).concat([wrappedHandler]));
+      };
+    });
+
+    shimmer.wrap(app, "head", function instrumentHead(original) {
+      return function(url, opts, handler) {
+        // TODO wrap the handler
+        return original.apply(this, [url, opts, handler]);
+      };
+    });
+
+    shimmer.wrap(app, "patch", function instrumentPatch(original) {
+      return function(url, opts, handler) {
+        // TODO wrap the handler
+        return original.apply(this, [url, opts, handler]);
+      };
+    });
+
+    shimmer.wrap(app, "post", function instrumentPost(original) {
+      return function(url, opts, handler) {
+        // TODO wrap the handler
+        return original.apply(this, [url, opts, handler]);
+      };
+    });
+
+    shimmer.wrap(app, "put", function instrumentPut(original) {
+      return function(url, opts, handler) {
+        // TODO wrap the handler
+        return original.apply(this, [url, opts, handler]);
+      };
+    });
+
+    shimmer.wrap(app, "options", function instrumentOptions(original) {
+      return function(url, opts, handler) {
+        // TODO wrap the handler
+        return original.apply(this, [url, opts, handler]);
+      };
+    });
+
+    shimmer.wrap(app, "all", function instrumentAll(original) {
+      return function(url, opts, handler) {
+        // TODO wrap the handler
+        return original.apply(this, [url, opts, handler]);
+      };
+    });
+
+    return app;
+  };
+
+  Object.defineProperties(wrapper, Object.getOwnPropertyDescriptors(fastify));
+  // install a shimmer-like flag here so we can test if we actually instrumented the library in tests.
+  wrapper.__wrapped = true;
+  return wrapper;
 };
 
 module.exports = instrumentFastify;

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -1,0 +1,268 @@
+/* eslint-env node, jest */
+const request = require("supertest"),
+  path = require("path"),
+  instrumentFastify = require("./fastify"),
+  cases = require("jest-in-case"),
+  schema = require("../schema"),
+  api = require("../api"),
+  pkg = require(path.join(__dirname, "..", "..", "package.json"));
+
+describe("userContext", () => {
+  function runCase(opts, done) {
+    const fastify = instrumentFastify(require("fastify"), opts);
+    expect(fastify.__wrapped).toBe(true);
+
+    let app;
+    function initializeTestServer(test) {
+      app = fastify();
+      app.get("/", function(request, reply) {
+        /* add a user */
+        request.user = {
+          id: 42,
+          username: "toshok",
+        };
+        reply.code(200).send("ok");
+      });
+
+      app.listen(3000, test);
+    }
+
+    api.configure({ impl: "mock" });
+    initializeTestServer(err => {
+      expect(err).toBeNull();
+      request(app.server)
+        .get("/")
+        .expect(200, () => {
+          const sentEvents = api._apiForTesting().sentEvents;
+          expect(sentEvents.length).toBe(2);
+
+          expect(sentEvents[0].startTime).not.toBeUndefined();
+          expect(sentEvents[0].startTimeHR).not.toBeUndefined();
+          delete sentEvents[0].startTime;
+          delete sentEvents[0].startTimeHR;
+
+          expect(sentEvents[1].startTime).not.toBeUndefined();
+          expect(sentEvents[1].startTimeHR).not.toBeUndefined();
+          delete sentEvents[1].startTime;
+          delete sentEvents[1].startTimeHR;
+
+          expect(sentEvents).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                [schema.TRACE_ID]: 0,
+                [schema.TRACE_PARENT_ID]: 50001,
+                [schema.TRACE_SPAN_ID]: 50002,
+                [schema.TRACE_SPAN_NAME]: "handler: GET /",
+                [schema.EVENT_TYPE]: "fastify",
+                [schema.PACKAGE_VERSION]: "1.1.1",
+                [schema.DURATION_MS]: 0,
+                [schema.BEELINE_VERSION]: pkg.version,
+              }),
+              expect.objectContaining({
+                [schema.TRACE_ID]: 0,
+                [schema.TRACE_SPAN_ID]: 50001,
+                [schema.TRACE_ID_SOURCE]: undefined,
+                [schema.TRACE_SPAN_NAME]: "request",
+                [schema.EVENT_TYPE]: "fastify",
+                [schema.PACKAGE_VERSION]: "1.1.1",
+                [schema.DURATION_MS]: 0,
+                [schema.BEELINE_VERSION]: pkg.version,
+                "request.host": "127.0.0.1:3000",
+                "request.route": undefined,
+                "request.original_url": "/",
+                "request.remote_addr": "127.0.0.1",
+                "request.method": "GET",
+                "request.query": {},
+                "request.http_version": "HTTP/1.1",
+                "request.user.id": 42,
+                "request.user.username": "toshok",
+                "response.status_code": "200",
+              }),
+            ])
+          );
+          api._resetForTesting();
+          app.close(done);
+        });
+    });
+  }
+
+  cases("cases", (opts, done) => runCase(opts, done), [
+    {
+      name: "field array userContext",
+      userContext: ["id", "username"],
+      packageVersion: "1.1.1",
+    },
+
+    {
+      description: "function userContext",
+      userContext: req => ({ id: req.user.id, username: req.user.username }),
+      packageVersion: "1.1.1",
+    },
+  ]);
+});
+
+describe("userContext as function", () => {
+  let cb_called = false;
+
+  const fastify = instrumentFastify(require("fastify"), {
+    userContext: () => {
+      cb_called = true;
+      return { random: "stuff" };
+    },
+  });
+
+  let app;
+  function initializeTestServer(test) {
+    app = fastify();
+    app.get("/", function(req, res) {
+      // don't add req.user here
+      res.code(200).send("ok");
+    });
+
+    app.listen(3000, test);
+  }
+
+  test("it's called even if req.user is undefined", done => {
+    api.configure({ impl: "mock" });
+    initializeTestServer(err => {
+      expect(err).toBeNull();
+      request(app.server)
+        .get("/")
+        .expect(200, () => {
+          expect(cb_called).toBe(true);
+          expect(api._apiForTesting().sentEvents.length).toBe(2);
+          let ev = api._apiForTesting().sentEvents[1]; // the request span
+          expect(ev["request.user.random"]).toBe("stuff");
+          api._resetForTesting();
+          app.close(done);
+        });
+    });
+  });
+});
+
+describe("request id from http headers", () => {
+  function runCase(opts, done) {
+    const fastify = instrumentFastify(require("fastify"));
+    expect(fastify.__wrapped).toBe(true);
+
+    let app;
+    function initializeTestServer(test) {
+      app = fastify();
+      app.get("/", function(request, reply) {
+        /* add a user */
+        request.user = {
+          id: 42,
+          username: "toshok",
+        };
+        reply.code(200).send("ok");
+      });
+
+      app.listen(3000, test);
+    }
+
+    api.configure({ impl: "mock" });
+    initializeTestServer(err => {
+      expect(err).toBeNull();
+      let r = request(app.server).get("/");
+
+      opts.headers.forEach(header => {
+        r = r.set(header.name, header.value);
+      });
+
+      r.expect(200, () => {
+        const sentEvents = api._apiForTesting().sentEvents;
+        expect(sentEvents.length).toBe(2);
+
+        let ev = api._apiForTesting().sentEvents[1];
+        expect(ev[schema.TRACE_ID]).toBe(opts.expectedHeaderValue);
+        expect(ev[schema.TRACE_ID_SOURCE]).toBe(`${opts.expectedHeaderName} http header`);
+
+        api._resetForTesting();
+        app.close(done);
+      });
+    });
+  }
+
+  cases("cases", (opts, done) => runCase(opts, done), [
+    {
+      name: "X-Request-ID works",
+      headers: [{ name: "X-Request-ID", value: "abc123" }],
+      expectedHeaderName: "X-Request-ID",
+      expectedHeaderValue: "abc123",
+    },
+
+    {
+      name: "X-Request-ID works",
+      headers: [{ name: "X-Amzn-Trace-Id", value: "Root=1-67891233-abcdef012345678912345678" }],
+      expectedHeaderName: "X-Amzn-Trace-Id",
+      expectedHeaderValue: "Root=1-67891233-abcdef012345678912345678",
+    },
+
+    {
+      name: "X-Request-ID > X-Amzn-Trace-Id",
+      headers: [
+        { name: "X-Request-ID", value: "abc123" },
+        { name: "X-Amzn-Trace-Id", value: "Root=1-67891233-abcdef012345678912345678" },
+      ],
+      expectedHeaderName: "X-Request-ID",
+      expectedHeaderValue: "abc123",
+    },
+  ]);
+});
+
+describe("trace id callback", () => {
+  function runCase(opts, done) {
+    const fastify = instrumentFastify(require("fastify"), {
+      traceIdSource: req => req.headers["x-request-id"] || "efgh456",
+    });
+    expect(fastify.__wrapped).toBe(true);
+
+    let app;
+    function initializeTestServer(test) {
+      app = fastify();
+      app.get("/", function(request, reply) {
+        reply.code(200).send("ok");
+      });
+
+      app.listen(3000, test);
+    }
+
+    api.configure({ impl: "mock" });
+    initializeTestServer(err => {
+      expect(err).toBeNull();
+      let r = request(app.server).get("/");
+
+      opts.headers.forEach(header => {
+        r = r.set(header.name, header.value);
+      });
+
+      r.expect(200, () => {
+        const sentEvents = api._apiForTesting().sentEvents;
+        expect(sentEvents.length).toBe(2);
+
+        let ev = api._apiForTesting().sentEvents[1];
+        expect(ev[schema.TRACE_ID]).toBe(opts.expectedTraceId);
+        expect(ev[schema.TRACE_ID_SOURCE]).toBe(opts.expectedTraceIdSource);
+
+        api._resetForTesting();
+        app.close(done);
+      });
+    });
+  }
+
+  cases("cases", (opts, done) => runCase(opts, done), [
+    {
+      name: "returns supplied X-Request-Id (calling the traceIdSource function)",
+      headers: [{ name: "X-Request-ID", value: "abc123" }],
+      expectedTraceId: "abc123",
+      expectedTraceIdSource: "traceIdSource function",
+    },
+
+    {
+      name: "returns static value if header isn't supplied",
+      headers: [],
+      expectedTraceId: "efgh456",
+      expectedTraceIdSource: "traceIdSource function",
+    },
+  ]);
+});

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -12,24 +12,24 @@ describe("userContext", () => {
     const fastify = instrumentFastify(require("fastify"), opts);
     expect(fastify.__wrapped).toBe(true);
 
-    let app;
-    function initializeTestServer(test) {
-      app = fastify();
-      app.get("/", function(request, reply) {
-        /* add a user */
-        request.user = {
-          id: 42,
-          username: "toshok",
-        };
-        reply.code(200).send("ok");
-      });
+    function initializeTestServer() {
+      return new Promise((resolve, reject) => {
+        const app = fastify();
+        app.get("/", function(request, reply) {
+          /* add a user */
+          request.user = {
+            id: 42,
+            username: "toshok",
+          };
+          reply.code(200).send("ok");
+        });
 
-      app.listen(3000, test);
+        app.listen(4000, err => (err ? reject(err) : resolve(app)));
+      });
     }
 
     api.configure({ impl: "mock" });
-    initializeTestServer(err => {
-      expect(err).toBeNull();
+    initializeTestServer().then(app => {
       request(app.server)
         .get("/")
         .expect(200, () => {
@@ -67,7 +67,7 @@ describe("userContext", () => {
                 [schema.PACKAGE_VERSION]: "1.1.1",
                 [schema.DURATION_MS]: 0,
                 [schema.BEELINE_VERSION]: pkg.version,
-                "request.host": "127.0.0.1:3000",
+                "request.host": "127.0.0.1:4000",
                 "request.route": undefined,
                 "request.original_url": "/",
                 "request.remote_addr": "127.0.0.1",
@@ -111,21 +111,21 @@ describe("userContext as function", () => {
     },
   });
 
-  let app;
-  function initializeTestServer(test) {
-    app = fastify();
-    app.get("/", function(req, res) {
-      // don't add req.user here
-      res.code(200).send("ok");
-    });
+  function initializeTestServer() {
+    return new Promise((resolve, reject) => {
+      const app = fastify();
+      app.get("/", function(req, res) {
+        // don't add req.user here
+        res.code(200).send("ok");
+      });
 
-    app.listen(3000, test);
+      app.listen(4000, err => (err ? reject(err) : resolve(app)));
+    });
   }
 
   test("it's called even if req.user is undefined", done => {
     api.configure({ impl: "mock" });
-    initializeTestServer(err => {
-      expect(err).toBeNull();
+    initializeTestServer().then(app => {
       request(app.server)
         .get("/")
         .expect(200, () => {
@@ -145,24 +145,24 @@ describe("request id from http headers", () => {
     const fastify = instrumentFastify(require("fastify"));
     expect(fastify.__wrapped).toBe(true);
 
-    let app;
-    function initializeTestServer(test) {
-      app = fastify();
-      app.get("/", function(request, reply) {
-        /* add a user */
-        request.user = {
-          id: 42,
-          username: "toshok",
-        };
-        reply.code(200).send("ok");
-      });
+    function initializeTestServer() {
+      return new Promise((resolve, reject) => {
+        const app = fastify();
+        app.get("/", function(request, reply) {
+          /* add a user */
+          request.user = {
+            id: 42,
+            username: "toshok",
+          };
+          reply.code(200).send("ok");
+        });
 
-      app.listen(3000, test);
+        app.listen(4000, err => (err ? reject(err) : resolve(app)));
+      });
     }
 
     api.configure({ impl: "mock" });
-    initializeTestServer(err => {
-      expect(err).toBeNull();
+    initializeTestServer().then(app => {
       let r = request(app.server).get("/");
 
       opts.headers.forEach(header => {
@@ -217,19 +217,19 @@ describe("trace id callback", () => {
     });
     expect(fastify.__wrapped).toBe(true);
 
-    let app;
-    function initializeTestServer(test) {
-      app = fastify();
-      app.get("/", function(request, reply) {
-        reply.code(200).send("ok");
-      });
+    function initializeTestServer() {
+      return new Promise((resolve, reject) => {
+        const app = fastify();
+        app.get("/", function(request, reply) {
+          reply.code(200).send("ok");
+        });
 
-      app.listen(3000, test);
+        app.listen(4000, err => (err ? reject(err) : resolve(app)));
+      });
     }
 
     api.configure({ impl: "mock" });
-    initializeTestServer(err => {
-      expect(err).toBeNull();
+    initializeTestServer().then(app => {
       let r = request(app.server).get("/");
 
       opts.headers.forEach(header => {

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -2,11 +2,11 @@
 const api = require("../api");
 
 // returns the header name/value for the first header with a value in the request.
-const getValueFromHeaders = (req, headers) => {
+const getValueFromHeaders = (requestHeaders, headers) => {
   let value, header;
 
   for (const h of headers) {
-    let headerValue = req.get(h);
+    let headerValue = requestHeaders[h];
     if (headerValue) {
       header = h; // source = `${h} http header`;
       value = headerValue;
@@ -27,7 +27,7 @@ exports.getTraceContext = (traceIdSource, req) => {
       typeof traceIdSource === "undefined"
         ? [api.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
         : [traceIdSource];
-    let valueAndHeader = getValueFromHeaders(req, headers);
+    let valueAndHeader = getValueFromHeaders(req.headers, headers);
 
     if (!valueAndHeader) {
       return {};

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -1,0 +1,93 @@
+/* eslint-env node */
+const api = require("../api");
+
+// returns the header name/value for the first header with a value in the request.
+const getValueFromHeaders = (req, headers) => {
+  let value, header;
+
+  for (const h of headers) {
+    let headerValue = req.get(h);
+    if (headerValue) {
+      header = h; // source = `${h} http header`;
+      value = headerValue;
+      break;
+    }
+  }
+
+  if (typeof value !== "undefined") {
+    return { value, header };
+  }
+
+  return undefined;
+};
+
+exports.getTraceContext = (traceIdSource, req) => {
+  if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
+    let headers =
+      typeof traceIdSource === "undefined"
+        ? [api.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
+        : [traceIdSource];
+    let valueAndHeader = getValueFromHeaders(req, headers);
+
+    if (!valueAndHeader) {
+      return {};
+    }
+    let { value, header } = valueAndHeader;
+
+    switch (header) {
+      case api.TRACE_HTTP_HEADER: {
+        let parsed = api.unmarshalTraceContext(value);
+        if (!parsed) {
+          return {};
+        }
+        return Object.assign({}, parsed, {
+          source: `${header} http header`,
+        });
+      }
+
+      default: {
+        return {
+          traceId: value,
+          source: `${header} http header`,
+        };
+      }
+    }
+  } else {
+    return {
+      traceId: traceIdSource(req),
+      source: "traceIdSource function",
+    };
+  }
+};
+
+exports.getUserContext = (userContext, req) => {
+  if (!userContext) {
+    return undefined;
+  }
+
+  // if we've got user data (from some other middleware), add it to the events
+  let keys;
+  let userObject;
+
+  if (Array.isArray(userContext) && req.user) {
+    keys = userContext;
+    userObject = req.user;
+  } else if (typeof userContext === "function") {
+    userObject = userContext(req);
+    keys = userObject && Object.keys(userObject);
+  }
+
+  if (!userObject) {
+    return undefined;
+  }
+
+  const userEventContext = {};
+
+  for (const k of keys) {
+    const v = userObject[k];
+    if (typeof v !== "function") {
+      userEventContext[`request.user.${k}`] = v;
+    }
+  }
+  return userEventContext;
+};

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -6,7 +6,7 @@ const getValueFromHeaders = (requestHeaders, headers) => {
   let value, header;
 
   for (const h of headers) {
-    let headerValue = requestHeaders[h];
+    let headerValue = requestHeaders[h.toLowerCase()];
     if (headerValue) {
       header = h; // source = `${h} http header`;
       value = headerValue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -526,6 +526,12 @@
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
     },
+    "abstract-logging": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
+      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -655,6 +661,12 @@
         "default-require-extensions": "^2.0.0"
       }
     },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
@@ -777,6 +789,17 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
       "dev": true
+    },
+    "avvio": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-6.2.1.tgz",
+      "integrity": "sha512-k+gTocL3yShwN1PtKEsSj7eFiApcZ4JZLAu/ecyzEb8jyx+Kmxb+7SXUsodB47g7fqhs/zkfsCdqq72a1ok5Ew==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "debug": "^4.0.0",
+        "fastq": "^1.6.0"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1567,6 +1590,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "dev": true
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -2262,6 +2291,12 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -2274,10 +2309,85 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
+    "fast-json-stringify": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.15.3.tgz",
+      "integrity": "sha512-p+ucnySTbrUQ9M7u8ygFIxrmpG8B+8O4/PvLDdh+RqMMgj/h6OoDb7U2lP+kqg3PDclQBFbSIArRhkorFwZLLg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.8.1",
+        "deepmerge": "^3.0.0"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-redact": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.5.0.tgz",
+      "integrity": "sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ==",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
+      "dev": true
+    },
+    "fastify": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.6.0.tgz",
+      "integrity": "sha512-3GxGV2P8731o2S5T6ng5NMJ9S7vFpZA4mk2mJEbMbhQ5aj1HhNGBOe39TYa2gWRrJVJuXxYYYIlY/5cFhiHpNg==",
+      "dev": true,
+      "requires": {
+        "abstract-logging": "^1.0.0",
+        "ajv": "^6.9.2",
+        "avvio": "^6.1.1",
+        "fast-json-stringify": "^1.15.0",
+        "find-my-way": "^2.0.0",
+        "flatstr": "^1.0.12",
+        "light-my-request": "^3.2.0",
+        "middie": "^4.0.1",
+        "pino": "^5.11.1",
+        "proxy-addr": "^2.0.4",
+        "readable-stream": "^3.1.1",
+        "rfdc": "^1.1.2",
+        "secure-json-parse": "^1.0.0",
+        "tiny-lru": "^6.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.0"
+      }
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -2370,6 +2480,17 @@
         }
       }
     },
+    "find-my-way": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.1.0.tgz",
+      "integrity": "sha512-Hdx6ctcrzkZH5y9EREHtXryXAgc5Bc8z5Cvoa61y9kaoYj2KU4yXD6h8b6u0NUkYPVmQQeRdf0AtG1kQxQ+ukQ==",
+      "dev": true,
+      "requires": {
+        "fast-decode-uri-component": "^1.0.0",
+        "safe-regex2": "^2.0.0",
+        "semver-store": "^0.3.0"
+      }
+    },
     "find-parent-dir": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
@@ -2420,6 +2541,12 @@
           }
         }
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+      "dev": true
     },
     "flatted": {
       "version": "2.0.0",
@@ -4721,6 +4848,38 @@
         "urljoin": "^0.1.5"
       }
     },
+    "light-my-request": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-3.4.1.tgz",
+      "integrity": "sha512-E1zMvRWjqsaCS60dTkD7c//xKV1KOFD2zo92Ru3o3e95lCfQSDCC9aS8MZm1V+zXaA/SeKDwK9gvrfaCseTusg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.8.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "lint-staged": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.5.tgz",
@@ -5170,6 +5329,24 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "middie": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/middie/-/middie-4.0.1.tgz",
+      "integrity": "sha512-eYK6EEHZiYpQMYPmeCb/vC9ZzJg1HCqi1ot/fQs1sPZKt/XREgXouQ7g6c9J5XvDV5203JjbpovCYNkHcHgTpQ==",
+      "dev": true,
+      "requires": {
+        "path-to-regexp": "^3.0.0",
+        "reusify": "^1.0.2"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.0.0.tgz",
+          "integrity": "sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==",
           "dev": true
         }
       }
@@ -5803,6 +5980,26 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.0.tgz",
+      "integrity": "sha512-cYmYb1bRp1NyCvi+HBjmlsDsojnMrcn0weYgcYvg4l6Oj3zi76RlNToPvQLT59D/jGgex36pH84sB5XIQ/GYAA==",
+      "dev": true,
+      "requires": {
+        "fast-redact": "^1.4.4",
+        "fast-safe-stringify": "^2.0.6",
+        "flatstr": "^1.0.9",
+        "pino-std-serializers": "^2.3.0",
+        "quick-format-unescaped": "^3.0.2",
+        "sonic-boom": "^0.7.3"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "dev": true
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -5979,6 +6176,12 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
       "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
+      "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA==",
+      "dev": true
     },
     "range-parser": {
       "version": "1.2.0",
@@ -6298,6 +6501,18 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rfdc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -6351,6 +6566,23 @@
         "ret": "~0.1.10"
       }
     },
+    "safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "dev": true,
+      "requires": {
+        "ret": "~0.2.0"
+      },
+      "dependencies": {
+        "ret": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+          "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+          "dev": true
+        }
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6397,6 +6629,12 @@
         "object-assign": "^4.1.1"
       }
     },
+    "secure-json-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-1.0.0.tgz",
+      "integrity": "sha512-kMg4jXttRQzVyLebIDc+MRxCueJ/zsmHpCn59BRd0mZUCd+V02wNd7/Pds8Nyhv7jfLHo1KkUOzdIF7cRMU4LQ==",
+      "dev": true
+    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -6407,6 +6645,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
+      "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==",
       "dev": true
     },
     "send": {
@@ -6706,6 +6950,15 @@
             "es6-promisify": "^5.0.0"
           }
         }
+      }
+    },
+    "sonic-boom": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.4.tgz",
+      "integrity": "sha512-8JRAJg0RxZtFLQMxolwETvWd2JSlH3ZGo/Z4xPxMbpqF14xCgVYPVeFCFOR3zyr3pcfG82QDVj6537Sx5ZWdNw==",
+      "dev": true,
+      "requires": {
+        "flatstr": "^1.0.9"
       }
     },
     "source-map": {
@@ -7157,6 +7410,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
+    },
+    "tiny-lru": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-6.0.1.tgz",
+      "integrity": "sha512-k/vdHz+bFALjmik0URLWBYNuO0hCABTL5dullbZBXvFDdlL8RrKaeLR6YuHfX+6ZXOLkHw+HpNLCUA7DtLMQmg==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "eslint": "^5.15.1",
     "express": "^4.16.4",
+    "fastify": "^2.5.0",
     "husky": "^1.3.1",
     "jest": "^24.3.1",
     "jest-in-case": "^1.0.2",


### PR DESCRIPTION
Introduce `fastify` auto-instrumentation.  It registers two hooks before anything in user-code is run, one `onRequest` to start the trace, and one `onResponse` to send it.  Given just how pervasively async the api is and how things are registered, it's not as easy to ensure that context gets propagated correctly through hooks, so instead we store off the trace context in a Map and fetch it for every hook.  This means that there may be blips where context is lost, but each hook/handler should begin anew with the context.

Things this PR probably needs to include:

- [x] hooks
- [x] route handlers (`.get`, `.put`, etc)
- [ ] middleware - skipping this for now.  if we have requests, can add it via another PR.
