### PR TITLE
Add instrumentation for `pg` package

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -18,9 +18,9 @@ const instrumentations = [
   "mongoose",
   "mpromise",
   "mysql2",
+  "pg",
   "react-dom/server",
   "sequelize",
-  "pg",
 ];
 
 let enabledInstrumentations = new Set(instrumentations);

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -20,6 +20,7 @@ const instrumentations = [
   "mysql2",
   "react-dom/server",
   "sequelize",
+  "pg",
 ];
 
 let enabledInstrumentations = new Set(instrumentations);
@@ -100,7 +101,6 @@ const instrumentLoad = (exports.instrumentLoad = (mod, loadRequest, parent, opts
   }
 
   let packageVersion = getPackageVersion(loadRequest, parent);
-
   debug(`loading instrumentation for ${loadRequest}@${packageVersion}`);
   let instrumentation = require(instrumentationPath(loadRequest));
   let new_mod;

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -3,6 +3,23 @@ const shimmer = require("shimmer"),
   api = require("../api"),
   schema = require("../schema");
 
+const getQueryString = function(args) {
+  if (typeof args[0] === "string") return args[0];
+  if (typeof args[0] === "object") return args[0].text;
+  return undefined;
+};
+
+const getQueryArgs = function(args) {
+  if (typeof args[0] === "object") return args[0].values;
+  if (Array.isArray(args[1])) return args[1];
+  return undefined;
+};
+
+const getQueryName = function(args) {
+  if (typeof args[0] === "object") return args[0].name;
+  return undefined;
+};
+
 let instrumentPg = function(pg, opts = {}) {
   shimmer.wrap(pg.Client.prototype, "query", function(query) {
     return function(...args) {
@@ -13,17 +30,14 @@ let instrumentPg = function(pg, opts = {}) {
         return query.apply(this, args);
       }
 
-      let queryString = args[0].text;
-      if (typeof queryString === "undefined") {
-        queryString = args[0];
-      }
       api.startAsyncSpan(
         {
           [schema.EVENT_TYPE]: "pg",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
           [schema.TRACE_SPAN_NAME]: "query",
-          "db.query": queryString,
-          "db.query_args": args[1],
+          "db.query": getQueryString(args),
+          "db.query_args": getQueryArgs(args),
+          "db.query_name": getQueryName(args),
         },
         span => {
           let cb = args[args.length - 1];

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -1,0 +1,62 @@
+/* eslint-env node */
+const shimmer = require("shimmer"),
+  api = require("../api"),
+  schema = require("../schema");
+
+let instrumentPg = function(pg, opts = {}) {
+  shimmer.wrap(pg.Client.prototype, "query", function(query) {
+    return function(...args) {
+      if (args.length < 1) {
+        return query.apply(this, args);
+      }
+      if (!api.traceActive()) {
+        return query.apply(this, args);
+      }
+
+      let queryString = args[0].text;
+      if (typeof queryString === "undefined") {
+        queryString = args[0];
+      }
+      api.startAsyncSpan(
+        {
+          [schema.EVENT_TYPE]: "pg",
+          [schema.PACKAGE_VERSION]: opts.packageVersion,
+          [schema.TRACE_SPAN_NAME]: "query",
+          "db.query": queryString,
+          "db.query_args": args[1],
+        },
+        span => {
+          let cb = args[args.length - 1];
+          // XXX(toshok) this bindFunction shouldn't be necessary, but we aren't
+          // finishing the event properly without it.
+          let wrapped_cb = api.bindFunctionToTrace(function(...cb_args) {
+            let error = cb_args[0];
+            let result = cb_args[1];
+
+            if (error !== null && error instanceof Error) {
+              api.addContext({
+                "db.error": error.message,
+                "db.error_stack": error.stack,
+                "db.error_hint": error.hint,
+              });
+            }
+
+            if (result) {
+              api.addContext({
+                "db.rows_affected": result.rowCount,
+              });
+            }
+
+            api.finishSpan(span, "query");
+            return cb(...cb_args);
+          });
+
+          return query.apply(this, args.slice(0, -1).concat(wrapped_cb));
+        }
+      );
+    };
+  });
+  return pg;
+};
+
+module.exports = instrumentPg;


### PR DESCRIPTION
Addresses issue #37.

Our team uses the [pg package](https://www.npmjs.com/package/pg) to manage our Postgres interactions and were looking to extend our tracing to include those queries to the database. Didn't see an easy way to introduce a custom instrumentation from our own codebase so looking to upstream and share.

A lot of this is based off the pre-existing mysql2 (thanks to @toshok and @ashishbista for their work on that one!) and also a little inspiration from [opentracing-auto's pg instrumentation](https://github.com/RisingStack/opentracing-auto/blob/master/src/instrumentation/pg.js).

Main difference to the mysql2 instrumentation is that this enhances the span with error/result information, similarly to [how beeline-python does it.](https://github.com/honeycombio/beeline-python/blob/master/beeline/middleware/django/__init__.py#L17)

[Here is a minimum project to test the instrumentation out with](https://github.com/allyjweir/pg-trace-example). Check the README.md for setup details.