### PR TITLE
update express instrumentation to correctly track `request.route` and `request.base_url`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Christine Yen
 Erwin van der Koogh
 Ally Weir
 Ashish Bista
+Mordy Tikotzky

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -131,6 +131,11 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
     api.addContext({
       "response.status_code": String(response.statusCode),
     });
+    if (req.route) {
+      api.addContext({
+        "request.route": req.route.path,
+      });
+    }
     if (req.params) {
       Object.keys(req.params).forEach(param =>
         api.addContext({

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -92,7 +92,6 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
       "request.remote_addr": req.ip,
       "request.secure": req.secure,
       "request.method": req.method,
-      "request.route": req.route ? req.route.path : undefined,
       "request.scheme": req.protocol,
       "request.path": req.path,
       "request.query": req.query,

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -87,7 +87,6 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
       [schema.TRACE_SPAN_NAME]: "request",
       [schema.TRACE_ID_SOURCE]: traceContext.source,
       "request.host": req.hostname,
-      "request.base_url": req.baseUrl,
       "request.original_url": req.originalUrl,
       "request.remote_addr": req.ip,
       "request.secure": req.secure,
@@ -128,6 +127,7 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
     }
 
     api.addContext({
+      "request.base_url": req.baseUrl,
       "response.status_code": String(response.statusCode),
     });
     if (req.route) {

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -133,16 +133,22 @@ describe("userContext as function", () => {
   });
 });
 
-describe("res.route.path", () => {
+describe("req proprties should only be read after a request matches a route", () => {
   const express = instrumentExpress(require("express"), {});
 
   let server;
   function initializeTestServer() {
     let app = express();
+    let router = express.Router();
     app.get("/:name", function(req, res) {
-      // don't add req.user here
       res.status(200).send("ok");
     });
+
+    router.get("/router/:name", function(req, res) {
+      res.status(200).send("ok");
+    });
+
+    app.use("/base", router);
 
     server = app.listen(3000);
   }
@@ -164,6 +170,19 @@ describe("res.route.path", () => {
           expect(api._apiForTesting().sentEvents.length).toBe(1);
           let ev = api._apiForTesting().sentEvents[0];
           expect(ev["request.route"]).toBe("/:name");
+          done();
+        }, 1000);
+      });
+  });
+
+  test("it correctly sends the matched base_url", done => {
+    request(server)
+      .get("/base/router/mordy")
+      .expect(200, () => {
+        setTimeout(() => {
+          expect(api._apiForTesting().sentEvents.length).toBe(1);
+          let ev = api._apiForTesting().sentEvents[0];
+          expect(ev["request.base_url"]).toBe("/base");
           done();
         }, 1000);
       });

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -53,7 +53,7 @@ describe("userContext", () => {
             [schema.BEELINE_VERSION]: pkg.version,
             "request.host": "127.0.0.1",
             "request.base_url": "",
-            "request.route": undefined,
+            "request.route": "/",
             "request.original_url": "/",
             "request.remote_addr": "::ffff:127.0.0.1",
             "request.secure": false,

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -133,6 +133,43 @@ describe("userContext as function", () => {
   });
 });
 
+describe("res.route.path", () => {
+  const express = instrumentExpress(require("express"), {});
+
+  let server;
+  function initializeTestServer() {
+    let app = express();
+    app.get("/:name", function(req, res) {
+      // don't add req.user here
+      res.status(200).send("ok");
+    });
+
+    server = app.listen(3000);
+  }
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+    initializeTestServer();
+  });
+  afterEach(() => {
+    api._resetForTesting();
+    server.close();
+  });
+
+  test("it correctly sends the matched path", done => {
+    request(server)
+      .get("/mordy")
+      .expect(200, () => {
+        setTimeout(() => {
+          expect(api._apiForTesting().sentEvents.length).toBe(1);
+          let ev = api._apiForTesting().sentEvents[0];
+          expect(ev["request.route"]).toBe("/:name");
+          done();
+        }, 1000);
+      });
+  });
+});
+
 describe("request id from http headers", () => {
   const express = instrumentExpress(require("express"), {});
 


### PR DESCRIPTION
Currently it add `request.route` to the context before express matches the request to a route.
This PR moves `request.route` to the `boundFinisher` so that it will only be added after express has already matched the request to a route and set `request.route`.