### PR TITLE
for circleci, publish should ignore branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,6 @@ workflows:
             - test_node11
           filters:
               branches:
-                only: master
+                ignore: /.*/
               tags:
                 only: /.+/


### PR DESCRIPTION
The `filters` clause is an OR, not AND.  so instead of encoding "master AND tagged", it's "master OR tagged".

This results in all PR merges causing a build failure on master since it attempts to npm publish a version that's already published.