### PR TITLE
Friendly error message if a trace doesn't exist when starting a span

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Erwin van der Koogh
 Ally Weir
 Ashish Bista
 Mordy Tikotzky
+Carter Bancroft

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -585,3 +585,21 @@ describe("presend hook", () => {
     expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
   });
 });
+
+test("startSpan throws an expected error with no trace", () => {
+  expect(tracker.getTracked()).toBeUndefined(); // context should be empty
+
+  let expectedError;
+  try {
+    event.startSpan({
+      context: "some_context",
+    });
+  } catch (err) {
+    expectedError = err;
+  } finally {
+    expect(expectedError).not.toBeUndefined();
+    expect(expectedError.message).toBe(
+      "Could not get context. Spans must be created within a trace."
+    );
+  }
+});

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -108,6 +108,11 @@ module.exports = class LibhoneyEventAPI {
 
   startSpan(metadataContext, spanId = uuidv4(), parentId = undefined) {
     let context = tracker.getTracked();
+
+    if (!context) {
+      throw new Error("Could not get context. Spans must be created within a trace.");
+    }
+
     if (context.stack.length > 0) {
       if (parentId) {
         debug("parentId supplied when there are already spans.. wrong.");


### PR DESCRIPTION
Before, when starting a span outside of a trace it would throw `Cannot read property 'stack' of undefined` from the `context.stack.length` line.

This was tricky for me to figure out because in some unit tests much of our code would be run via an express endpoint call (which the beeline would instrument automatically) but in other cases where we're testing a particular unit outside of an express call it would fail. Until I properly understood context I couldn't grok why certain tests against code with spans would pass and others would fail.

A clearer error would hopefully make it more obvious what's happening.

I'm sort of guessing at a proper error message... if you like these changes but not the message let me know what might be better.