### PR TITLE
Adding support for setting user requested parent span id

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -180,7 +180,7 @@ let instrumentExpress = function(express, opts = {}) {
       parentIdSource = opts.parentIdSource;
     } else {
       debug(
-        "parentIdSource option must either be an string"
+        "parentIdSource option must  be a string"
       );
     }
   }

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -79,7 +79,11 @@ function wrapErrMiddleware(middleware, debugWrap) {
 }
 
 const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packageVersion }) => (req, res, next) => {
-  let traceContext = traceUtil.getTraceContext(traceIdSource, parentIdSource, req);
+  let traceContext = traceUtil.getTraceContext(traceIdSource, req);
+  let parentTraceId = traceUtil.getParentSourceId(parentIdSource, req);
+  if(parentTraceId){
+    traceContext["parentSpanId"] = parentTraceId;
+  }
   let trace = api.startTrace(
     {
       [schema.EVENT_TYPE]: "express",
@@ -176,11 +180,11 @@ let instrumentExpress = function(express, opts = {}) {
   }
 
   if (opts.parentIdSource) {
-    if (typeof opts.parentIdSource === "string") {
+    if (typeof opts.parentIdSource === "string" || typeof opts.traceIdSource === "function") {
       parentIdSource = opts.parentIdSource;
     } else {
       debug(
-        "parentIdSource option must  be a string"
+        "parentIdSource option must either be an string (the http header name) or a function returning the string request id"
       );
     }
   }

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -81,7 +81,7 @@ function wrapErrMiddleware(middleware, debugWrap) {
 const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packageVersion }) => (req, res, next) => {
   let traceContext = traceUtil.getTraceContext(traceIdSource, req);
   let parentTraceId = traceUtil.getParentSourceId(parentIdSource, req);
-  if(parentTraceId){
+  if (parentTraceId) {
     traceContext["parentSpanId"] = parentTraceId;
   }
   let trace = api.startTrace(

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -78,8 +78,8 @@ function wrapErrMiddleware(middleware, debugWrap) {
   };
 }
 
-const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (req, res, next) => {
-  let traceContext = traceUtil.getTraceContext(traceIdSource, req);
+const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packageVersion }) => (req, res, next) => {
+  let traceContext = traceUtil.getTraceContext(traceIdSource, parentIdSource, req);
   let trace = api.startTrace(
     {
       [schema.EVENT_TYPE]: "express",
@@ -153,7 +153,7 @@ const getMagicMiddleware = ({ userContext, traceIdSource, packageVersion }) => (
 };
 
 let instrumentExpress = function(express, opts = {}) {
-  let userContext, traceIdSource;
+  let userContext, traceIdSource, parentIdSource;
 
   if (opts.userContext) {
     if (Array.isArray(opts.userContext) || typeof opts.userContext === "function") {
@@ -175,6 +175,16 @@ let instrumentExpress = function(express, opts = {}) {
     }
   }
 
+  if (opts.parentIdSource) {
+    if (typeof opts.parentIdSource === "string") {
+      parentIdSource = opts.parentIdSource;
+    } else {
+      debug(
+        "parentIdSource option must either be an string"
+      );
+    }
+  }
+
   let packageVersion = opts.packageVersion;
 
   let debugWrapMiddleware =
@@ -182,7 +192,7 @@ let instrumentExpress = function(express, opts = {}) {
   const wrapper = function() {
     const app = express();
     // put our middleware in the chain at the start
-    app.use(getMagicMiddleware({ userContext, traceIdSource, packageVersion }));
+    app.use(getMagicMiddleware({ userContext, traceIdSource, parentIdSource, packageVersion }));
 
     // and wrap every other middleware's bind/error functions so we can 1) detect context loss, and 2) warn the user about it.
     shimmer.wrap(express.Router, "use", function instrumentUse(original) {

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -55,7 +55,7 @@ const instrumentFastify = function(fastify, opts = {}) {
       // start our trace handling
       let traceContext = traceUtil.getTraceContext(traceIdSource, request);
       let parentTraceId = traceUtil.getParentSourceId(parentIdSource, request);
-      if(parentTraceId){
+      if (parentTraceId) {
         traceContext["parentSpanId"] = parentTraceId;
       }
       let trace = api.startTrace(

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -15,7 +15,7 @@ function isPromise(p) {
 }
 
 const instrumentFastify = function(fastify, opts = {}) {
-  let userContext, traceIdSource;
+  let userContext, traceIdSource, parentIdSource;
   if (opts.userContext) {
     if (Array.isArray(opts.userContext) || typeof opts.userContext === "function") {
       userContext = opts.userContext;
@@ -35,6 +35,16 @@ const instrumentFastify = function(fastify, opts = {}) {
     }
   }
 
+  if (opts.parentIdSource) {
+    if (typeof opts.parentIdSource === "string") {
+      parentIdSource = opts.parentIdSource;
+    } else {
+      debug(
+        "parentIdSource option must either be an string"
+      );
+    }
+  }
+
   const trackedByRequest = new Map();
   const finishersByRequest = new Map();
 
@@ -43,7 +53,7 @@ const instrumentFastify = function(fastify, opts = {}) {
 
     app.addHook("onRequest", (request, reply, next) => {
       // start our trace handling
-      let traceContext = traceUtil.getTraceContext(traceIdSource, request);
+      let traceContext = traceUtil.getTraceContext(traceIdSource, parentIdSource, request);
       let trace = api.startTrace(
         {
           [schema.EVENT_TYPE]: "fastify",

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -54,7 +54,7 @@ const instrumentFastify = function(fastify, opts = {}) {
     app.addHook("onRequest", (request, reply, next) => {
       // start our trace handling
       let traceContext = traceUtil.getTraceContext(traceIdSource, request);
-      let parentTraceId = traceUtil.getParentSourceId(parentIdSource, req);
+      let parentTraceId = traceUtil.getParentSourceId(parentIdSource, request);
       if(parentTraceId){
         traceContext["parentSpanId"] = parentTraceId;
       }

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -40,7 +40,7 @@ const instrumentFastify = function(fastify, opts = {}) {
       parentIdSource = opts.parentIdSource;
     } else {
       debug(
-        "parentIdSource option must either be an string"
+        "parentIdSource option must be a string"
       );
     }
   }

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -36,11 +36,11 @@ const instrumentFastify = function(fastify, opts = {}) {
   }
 
   if (opts.parentIdSource) {
-    if (typeof opts.parentIdSource === "string") {
+    if (typeof opts.parentIdSource === "string" || typeof opts.traceIdSource === "function") {
       parentIdSource = opts.parentIdSource;
     } else {
       debug(
-        "parentIdSource option must be a string"
+        "parentIdSource option must either be an string (the http header name) or a function returning the string request id"
       );
     }
   }
@@ -53,7 +53,11 @@ const instrumentFastify = function(fastify, opts = {}) {
 
     app.addHook("onRequest", (request, reply, next) => {
       // start our trace handling
-      let traceContext = traceUtil.getTraceContext(traceIdSource, parentIdSource, request);
+      let traceContext = traceUtil.getTraceContext(traceIdSource, request);
+      let parentTraceId = traceUtil.getParentSourceId(parentIdSource, req);
+      if(parentTraceId){
+        traceContext["parentSpanId"] = parentTraceId;
+      }
       let trace = api.startTrace(
         {
           [schema.EVENT_TYPE]: "fastify",

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -26,7 +26,7 @@ exports.getTraceContext = (traceIdSource, req) => {
     let headers =
       typeof traceIdSource === "undefined"
         ? [api.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
-        : [traceIdSource];
+        : [traceIdSource.split(";")[0]];
     let valueAndHeader = getValueFromHeaders(req.headers, headers);
 
     if (!valueAndHeader) {
@@ -46,10 +46,14 @@ exports.getTraceContext = (traceIdSource, req) => {
       }
 
       default: {
-        return {
+        let traceContext = {
           traceId: value,
           source: `${header} http header`,
         };
+        if (typeof traceIdSource !== "undefined" && traceIdSource.split(";").length === 2) {
+          traceContext["parentSpanId"] = req.headers[traceIdSource.split(";")[1]]
+        };
+        return traceContext;
       }
     }
   } else {

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -21,7 +21,7 @@ const getValueFromHeaders = (requestHeaders, headers) => {
   return undefined;
 };
 
-exports.getTraceContext = (traceIdSource, parentIdSource, req) => {
+exports.getTraceContext = (traceIdSource, req) => {
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
       typeof traceIdSource === "undefined"
@@ -46,14 +46,10 @@ exports.getTraceContext = (traceIdSource, parentIdSource, req) => {
       }
 
       default: {
-        let traceContext = {
+        return {
           traceId: value,
           source: `${header} http header`,
         };
-        if (typeof parentIdSource !== "undefined") {
-          traceContext["parentSpanId"] = req.headers[parentIdSource]
-        }
-        return traceContext;
       }
     }
   } else {
@@ -63,6 +59,14 @@ exports.getTraceContext = (traceIdSource, parentIdSource, req) => {
     };
   }
 };
+
+exports.getParentSourceId = (parentIdSource, req) => {
+  if (typeof parentIdSource === "string") {
+    return req.headers[parentIdSource];
+  } else if(typeof traceIdSource === "function") {
+    return parentIdSource(req);
+  }
+};  
 
 exports.getUserContext = (userContext, req) => {
   if (!userContext) {

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -63,7 +63,7 @@ exports.getTraceContext = (traceIdSource, req) => {
 exports.getParentSourceId = (parentIdSource, req) => {
   if (typeof parentIdSource === "string") {
     return req.headers[parentIdSource];
-  } else if(typeof traceIdSource === "function") {
+  } else if (typeof traceIdSource === "function") {
     return parentIdSource(req);
   }
 };  

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -21,12 +21,12 @@ const getValueFromHeaders = (requestHeaders, headers) => {
   return undefined;
 };
 
-exports.getTraceContext = (traceIdSource, req) => {
+exports.getTraceContext = (traceIdSource, parentIdSource, req) => {
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
       typeof traceIdSource === "undefined"
         ? [api.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
-        : [traceIdSource.split(";")[0]];
+        : [traceIdSource];
     let valueAndHeader = getValueFromHeaders(req.headers, headers);
 
     if (!valueAndHeader) {
@@ -50,9 +50,9 @@ exports.getTraceContext = (traceIdSource, req) => {
           traceId: value,
           source: `${header} http header`,
         };
-        if (typeof traceIdSource !== "undefined" && traceIdSource.split(";").length === 2) {
-          traceContext["parentSpanId"] = req.headers[traceIdSource.split(";")[1]]
-        };
+        if (typeof parentIdSource !== "undefined") {
+          traceContext["parentSpanId"] = req.headers[parentIdSource]
+        }
         return traceContext;
       }
     }


### PR DESCRIPTION
 Right now at lifion we are using existing trace and span Ids generated at our end instead of beeline generated Ids. As there is no way to tell beeline about user generated span Id, the spans are loading into honeycomb with out parent ids. As a result we are seeing lot missing parent spans and broken traces.
This PR provides support for adding custom  parent span Id.
If needed users can pass parentIdSource value while initialising beeline module .