### PR TITLE
[pg] we need to return the promise

### DIFF
--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -30,7 +30,7 @@ let instrumentPg = function(pg, opts = {}) {
         return query.apply(this, args);
       }
 
-      api.startAsyncSpan(
+      return api.startAsyncSpan(
         {
           [schema.EVENT_TYPE]: "pg",
           [schema.PACKAGE_VERSION]: opts.packageVersion,


### PR DESCRIPTION
our `query` shim was executing the query properly if instrumentation was active, but it wasn't returning the promise back, leading to

```
TypeError: Cannot read property 'then' of undefined
```

This should fix things.