### PR TITLE
Don't capture MongoDB session objects

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -51,7 +51,6 @@ function instrumentMongodb(mongodb, opts = {}) {
           },
           span => {
             if (options) {
-              delete options["session"];
               api.addContext(prefixKeys("db.options", {
                 ...options,
                 session: undefined,

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -52,7 +52,10 @@ function instrumentMongodb(mongodb, opts = {}) {
           span => {
             if (options) {
               delete options["session"];
-              api.addContext(prefixKeys("db.options", options));
+              api.addContext(prefixKeys("db.options", {
+                ...options,
+                session: undefined,
+              }));
             }
             if (additionalContext) {
               api.addContext(prefixKeys("db", additionalContext(...populatedArgs)));

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -51,6 +51,7 @@ function instrumentMongodb(mongodb, opts = {}) {
           },
           span => {
             if (options) {
+              delete options["session"];
               api.addContext(prefixKeys("db.options", options));
             }
             if (additionalContext) {


### PR DESCRIPTION
The MongoDB session object is passed into some calls as `options.session` and cannot be serialised to JSON, thus crashing the instrumentation.

Fixes #157