### PR TITLE
PG instrumentation callbacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,13 @@ executors:
         default: "12"
     docker:
       - image: circleci/node:<< parameters.nodeversion >>
-
+        environment:
+          PGUSER: root
+          PGDATABASE: circle_test
+      - image: circleci/postgres:9-alpine-ram
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
 jobs:
   test_libhoney:
     parameters:

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -76,6 +76,10 @@ let instrumentPg = function(pg, opts = {}) {
               config.callback = wrapper(span, config.callback);
             } else if (typeof values === "function") {
               values = wrapper(span, values);
+            } else {
+              if (typeof config.on === "function") {
+                config.on("close", wrapper(span, () => {}));
+              }
             }
           } else {
             if (typeof callback === "function") {

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -3,27 +3,36 @@ const shimmer = require("shimmer"),
   api = require("../api"),
   schema = require("../schema");
 
-const getQueryString = function(args) {
-  if (typeof args[0] === "string") return args[0];
-  if (typeof args[0] === "object") return args[0].text;
+const getQueryString = function([config]) {
+  if (typeof config === "string") return config;
+  if (typeof config === "object") {
+    if (typeof config.cursor === "object") {
+      return config.cursor.text;
+    }
+    return config.text;
+  }
   return undefined;
 };
 
-const getQueryArgs = function(args) {
-  if (typeof args[0] === "object") return args[0].values;
-  if (Array.isArray(args[1])) return args[1];
+const getQueryArgs = function([config, values]) {
+  if (typeof config === "object") {
+    if (typeof config.cursor === "object") {
+      return config.cursor.values;
+    }
+    return config.values;
+  }
+  if (Array.isArray(values)) return values;
   return undefined;
 };
 
-const getQueryName = function(args) {
-  if (typeof args[0] === "object") return args[0].name;
+const getQueryName = function([config]) {
+  if (typeof config === "object") return config.name;
   return undefined;
 };
 
 const wrapper = (span, cb) => {
   return api.bindFunctionToTrace((...cb_args) => {
-    let error = cb_args[0];
-    let result = cb_args[1];
+    const [error, result] = cb_args;
 
     if (error !== null && error instanceof Error) {
       api.addContext({
@@ -40,6 +49,7 @@ const wrapper = (span, cb) => {
     }
 
     api.finishSpan(span, "query");
+
     return cb(...cb_args);
   });
 };

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -20,6 +20,30 @@ const getQueryName = function(args) {
   return undefined;
 };
 
+const wrapper = (span, cb) => {
+  return api.bindFunctionToTrace((...cb_args) => {
+    let error = cb_args[0];
+    let result = cb_args[1];
+
+    if (error !== null && error instanceof Error) {
+      api.addContext({
+        "db.error": error.message,
+        "db.error_stack": error.stack,
+        "db.error_hint": error.hint,
+      });
+    }
+
+    if (result) {
+      api.addContext({
+        "db.rows_affected": result.rowCount,
+      });
+    }
+
+    api.finishSpan(span, "query");
+    return cb(...cb_args);
+  });
+};
+
 let instrumentPg = function(pg, opts = {}) {
   shimmer.wrap(pg.Client.prototype, "query", function(query) {
     return function(...args) {
@@ -43,27 +67,7 @@ let instrumentPg = function(pg, opts = {}) {
           let cb = args[args.length - 1];
           // XXX(toshok) this bindFunction shouldn't be necessary, but we aren't
           // finishing the event properly without it.
-          let wrapped_cb = api.bindFunctionToTrace(function(...cb_args) {
-            let error = cb_args[0];
-            let result = cb_args[1];
-
-            if (error !== null && error instanceof Error) {
-              api.addContext({
-                "db.error": error.message,
-                "db.error_stack": error.stack,
-                "db.error_hint": error.hint,
-              });
-            }
-
-            if (result) {
-              api.addContext({
-                "db.rows_affected": result.rowCount,
-              });
-            }
-
-            api.finishSpan(span, "query");
-            return cb(...cb_args);
-          });
+          let wrapped_cb = wrapper(span, cb);
 
           return query.apply(this, args.slice(0, -1).concat(wrapped_cb));
         }

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -64,12 +64,28 @@ let instrumentPg = function(pg, opts = {}) {
           "db.query_name": getQueryName(args),
         },
         span => {
-          let cb = args[args.length - 1];
-          // XXX(toshok) this bindFunction shouldn't be necessary, but we aren't
-          // finishing the event properly without it.
-          let wrapped_cb = wrapper(span, cb);
+          let [config, values, callback] = args;
+          // we could be given the following:
+          // query string, values, callback
+          // query string, callback
+          // Query object
+          // Query object, callback
+          if (typeof config.submit === "function") {
+            // we have a 'Query' like object
+            if (config.callback) {
+              config.callback = wrapper(span, config.callback);
+            } else if (typeof values === "function") {
+              values = wrapper(span, values);
+            }
+          } else {
+            if (typeof callback === "function") {
+              callback = wrapper(span, callback);
+            } else if (typeof values === "function") {
+              values = wrapper(span, values);
+            }
+          }
 
-          return query.apply(this, args.slice(0, -1).concat(wrapped_cb));
+          return query.apply(this, [config, values, callback]);
         }
       );
     };

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -1,0 +1,65 @@
+/* eslint-env node, jest */
+const api = require("../api"),
+  instrumentPG = require("./pg");
+
+const pg = instrumentPG(require("pg"));
+
+describe("pg", () => {
+  const callback = (client, trace, done) => {
+    return () => {
+      api.finishTrace(trace);
+      client.end();
+      const [event] = api._apiForTesting().sentEvents;
+      expect(event).toMatchObject({
+        "db.query": expect.any(String),
+        "db.rows_affected": expect.any(Number),
+      });
+      done();
+    };
+  };
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+  });
+
+  afterEach(() => {
+    api._resetForTesting();
+  });
+
+  test("basic query with callback", done => {
+    const trace = api.startTrace();
+    const client = new pg.Client();
+    client.connect();
+    client.query("SELECT 1;", callback(client, trace, done));
+  });
+
+  test("basic query with values and callback", done => {
+    const trace = api.startTrace();
+    const client = new pg.Client();
+    client.connect();
+    client.query("select $1::text as name;", ["honeycomb"], callback(client, trace, done));
+  });
+
+  test("query config object with callback", done => {
+    const trace = api.startTrace();
+    const client = new pg.Client();
+    client.connect();
+    const query = {
+      text: "select $1::text as name;",
+      values: ["honeycomb"],
+    };
+    client.query(query, callback(client, trace, done));
+  });
+
+  test("query object with internal callback", done => {
+    const trace = api.startTrace();
+    const client = new pg.Client();
+    client.connect();
+    const query = new pg.Query(
+      "select $1::text as name",
+      ["brianc"],
+      callback(client, trace, done)
+    );
+    client.query(query);
+  });
+});

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -1,18 +1,18 @@
 /* eslint-env node, jest */
 const api = require("../api"),
-  instrumentPG = require("./pg");
+  instrumentPG = require("./pg"),
+  QueryStream = require("pg-query-stream");
 
 const pg = instrumentPG(require("pg"));
 
 describe("pg", () => {
   const callback = (client, trace, done) => {
     return () => {
-      api.finishTrace(trace);
       client.end();
-      const [event] = api._apiForTesting().sentEvents;
+      const events = api._apiForTesting().sentEvents;
+      const event = events.find(e => e.name === "query");
       expect(event).toMatchObject({
         "db.query": expect.any(String),
-        "db.rows_affected": expect.any(Number),
       });
       done();
     };
@@ -27,21 +27,23 @@ describe("pg", () => {
   });
 
   test("basic query with callback", done => {
-    const trace = api.startTrace();
+    const trace = api.startTrace({ name: "pg-test" });
     const client = new pg.Client();
     client.connect();
     client.query("SELECT 1;", callback(client, trace, done));
+    api.finishTrace(trace);
   });
 
   test("basic query with values and callback", done => {
-    const trace = api.startTrace();
+    const trace = api.startTrace({ name: "pg-test" });
     const client = new pg.Client();
     client.connect();
     client.query("select $1::text as name;", ["honeycomb"], callback(client, trace, done));
+    api.finishTrace(trace);
   });
 
   test("query config object with callback", done => {
-    const trace = api.startTrace();
+    const trace = api.startTrace({ name: "pg-test" });
     const client = new pg.Client();
     client.connect();
     const query = {
@@ -49,10 +51,11 @@ describe("pg", () => {
       values: ["honeycomb"],
     };
     client.query(query, callback(client, trace, done));
+    api.finishTrace(trace);
   });
 
   test("query object with internal callback", done => {
-    const trace = api.startTrace();
+    const trace = api.startTrace({ name: "pg-test" });
     const client = new pg.Client();
     client.connect();
     const query = new pg.Query(
@@ -61,5 +64,17 @@ describe("pg", () => {
       callback(client, trace, done)
     );
     client.query(query);
+    api.finishTrace(trace);
+  });
+
+  test("pg-query-stream", done => {
+    const trace = api.startTrace({ name: "pg-test" });
+    const client = new pg.Client();
+    client.connect();
+    const query = new QueryStream("SELECT * FROM generate_series(0, $1) num", [10]);
+    const stream = client.query(query);
+    stream.on("close", callback(client, trace, done));
+    stream.on("readable", stream.read);
+    api.finishTrace(trace);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1099,6 +1099,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -5860,6 +5866,12 @@
         "thunkify": "^2.1.2"
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
@@ -5956,6 +5968,69 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "pg": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.14.0.tgz",
+      "integrity": "sha512-TLsdOWKFu44vHdejml4Uoo8h0EwCjdIj9Z9kpz7pA5i8iQxOTwVb1+Fy+X86kW5AXKxQpYpYDs4j/qPDbro/lg==",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "^2.0.7",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+          "dev": true
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+      "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw==",
+      "dev": true
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "dev": true,
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -6035,6 +6110,33 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA==",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -7040,6 +7142,15 @@
       "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7947,6 +8058,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5997,6 +5997,12 @@
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
       "dev": true
     },
+    "pg-cursor": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.0.1.tgz",
+      "integrity": "sha512-AfPaRh6N32HrXB8/D0JXfJWdLCn8U+Z4LEf8C954aSFTjhZqt7QbyAYyN5k1E4cv0HQjwW70G1xywQ5ZECzPPg==",
+      "dev": true
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -6008,6 +6014,15 @@
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
       "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw==",
       "dev": true
+    },
+    "pg-query-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-2.0.1.tgz",
+      "integrity": "sha512-yiAbAkZHe3lgoQt0BdhqVe0KJ2ggB9yAUzpiNrbRpvolBMFIeO/RNsbR+V3Opigk2YiXNc1rjsTHLAd0Sj1iMg==",
+      "dev": true,
+      "requires": {
+        "pg-cursor": "^2.0.1"
+      }
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "^24.9.0",
     "jest-in-case": "^1.0.2",
     "lint-staged": "^8.1.5",
+    "pg": "^7.14.0",
     "prettier": "^1.16.4",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jest-in-case": "^1.0.2",
     "lint-staged": "^8.1.5",
     "pg": "^7.14.0",
+    "pg-query-stream": "^2.0.1",
     "prettier": "^1.16.4",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",


### PR DESCRIPTION
Try to better handle the arguments being passed to the `query` function. It looks like having these three arguments have been pretty stable for many years. 

We need to decipher where in the arguments the callback lives. From reading the source, it looks like the options are these:

// query string, values, callback
// query string, callback
// Query like object
// Query like object, callback

Once we have deciphered where the correct callback lives we wrap it and pass it onto the wrapped `query` function.

This seems to work in my local manual testing. Looking into how to add some unit tests for this as well.

Resolves #173. 