### PR TITLE
Add lint step & fix lint error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,15 @@ workflows:
   build-libhoney:
     jobs:
       - test_libhoney:
+          name: lint
+          nodeversion: "12"
+          npm_task: "run lint"
+      - test_libhoney:
           name: test_node891
           nodeversion: "8.9.1"
           npm_install: "i"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -63,6 +69,8 @@ workflows:
           name: test_node9
           nodeversion: "9"
           npm_install: "i"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -72,6 +80,8 @@ workflows:
           name: test_node1000
           nodeversion: "10.0.0"
           npm_install: "i"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -80,6 +90,8 @@ workflows:
       - test_libhoney:
           name: test_node10
           nodeversion: "10"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -88,6 +100,8 @@ workflows:
       - test_libhoney:
           name: test_node11
           nodeversion: "11"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -96,6 +110,8 @@ workflows:
       - test_libhoney:
           name: test_node12
           nodeversion: "12"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,16 @@ jobs:
       npm_install:
         type: string
         default: "ci"
+      npm_task:
+        type: string
+        default: "test"
     executor:
       name: node
       nodeversion: "<< parameters.nodeversion >>"
     steps:
       - checkout
       - run: npm << parameters.npm_install >>
-      - run: npm test
+      - run: npm << parameters.npm_task >>
 
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,6 @@ jobs:
           name: store npm auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm ci
-      - run: npm run lint
       - run: npm publish
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ workflows:
             - test_node1000
             - test_node10
             - test_node11
+            - test_node12
           filters:
               branches:
                 ignore: /.*/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   },
   "extends": ["eslint:recommended"],
   "parserOptions": {
-    "ecmaVersion": 2015
+    "ecmaVersion": 2018
   },
   "rules": {
     "no-console": "off",


### PR DESCRIPTION
Previously we only ran the lint step as part of the publish step which meant that any lint errors would block publishing.

This creates a new job that performs the linting before any of the test steps runs and removes the lint from the publish step.

In order to fix the existing lint error we had to set the ecma version to 2018.
