### PR TITLE
[fastify] only wrap the request/reply hooks

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -48,6 +48,19 @@ const instrumentFastify = function(fastify, opts = {}) {
   const trackedByRequest = new Map();
   const finishersByRequest = new Map();
 
+  // we only wrap the hooks that deal with requests.  we should look into wrapping the non request/reply hooks at
+  // some point.
+  const wrappedHookNames = [
+    "onRequest",
+    "preParsing",
+    "preValidation",
+    "preHandler",
+    "preSerialization",
+    "onError",
+    "onSend",
+    "onResponse",
+  ];
+
   const wrapper = function(...args) {
     const app = fastify(...args);
 
@@ -127,9 +140,7 @@ const instrumentFastify = function(fastify, opts = {}) {
     // others will show up as spans in the trace.
     shimmer.wrap(app, "addHook", function instrumentAddHook(original) {
       return function(hookName, hookFn) {
-        if (hookName == "onResponse") {
-          // we need to skip onResponse hooks, because we will have already ended the
-          // trace.  we need a way to manipulate onResponse hooks
+        if (wrappedHookNames.indexOf(hookName) === -1) {
           return original.apply(this, [hookName, hookFn]);
         }
 
@@ -137,6 +148,10 @@ const instrumentFastify = function(fastify, opts = {}) {
           let request = args[0];
 
           let tracked = trackedByRequest.get(request);
+          if (!tracked) {
+            return hookFn.apply(this, args);
+          }
+
           tracker.setTracked(tracked);
 
           let span = api.startSpan({

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -58,7 +58,11 @@ const instrumentFastify = function(fastify, opts = {}) {
     "preSerialization",
     "onError",
     "onSend",
-    "onResponse",
+    // TODO(toshok):
+    // we need to skip onResponse hooks, because by the time this hook is invoked, we will have already ended the
+    // trace.  There may be a way to instrument these (we'd need to end the trace after onResponse) - we should
+    // figure it out.
+    // "onResponse",
   ];
 
   const wrapper = function(...args) {


### PR DESCRIPTION
Add a whitelist for request/reply hooks (https://github.com/fastify/fastify/blob/master/docs/Hooks.md), and just pass the others through unshimmed (the shim code assumes we're dealing with those hooks currently.)

Also make things a bit more robust by not crashing if there are requests that somehow didn't start a trace.