### PR TITLE
Pull prefix & "=" out of x-amzn-trace-id

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Erwin van der Koogh
 Ally Weir
 Ashish Bista
 Mordy Tikotzky
+Cameron Dunn

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -232,7 +232,7 @@ describe("request id from http headers", () => {
       .expect(200, () => {
         expect(api._apiForTesting().sentEvents.length).toBe(1);
         let ev = api._apiForTesting().sentEvents[0];
-        expect(ev[schema.TRACE_ID]).toBe("Root=1-67891233-abcdef012345678912345678");
+        expect(ev[schema.TRACE_ID]).toBe("1-67891233-abcdef012345678912345678");
         expect(ev[schema.TRACE_ID_SOURCE]).toBe("X-Amzn-Trace-Id http header");
         done();
       });

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -195,7 +195,7 @@ describe("request id from http headers", () => {
       name: "X-Request-ID works",
       headers: [{ name: "X-Amzn-Trace-Id", value: "Root=1-67891233-abcdef012345678912345678" }],
       expectedHeaderName: "X-Amzn-Trace-Id",
-      expectedHeaderValue: "Root=1-67891233-abcdef012345678912345678",
+      expectedHeaderValue: "1-67891233-abcdef012345678912345678",
     },
 
     {

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -21,11 +21,13 @@ const getValueFromHeaders = (requestHeaders, headers) => {
   return undefined;
 };
 
+const X_AMZN_TRACE_ID_HEADER = "X-Amzn-Trace-Id";
+
 exports.getTraceContext = (traceIdSource, req) => {
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
       typeof traceIdSource === "undefined"
-        ? [api.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
+        ? [api.TRACE_HTTP_HEADER, "X-Request-ID", X_AMZN_TRACE_ID_HEADER]
         : [traceIdSource];
     let valueAndHeader = getValueFromHeaders(req.headers, headers);
 
@@ -43,6 +45,14 @@ exports.getTraceContext = (traceIdSource, req) => {
         return Object.assign({}, parsed, {
           source: `${header} http header`,
         });
+      }
+
+      case X_AMZN_TRACE_ID_HEADER: {
+        return {
+          // Don't pass along "Root=" as it can break parsing further down the chain.
+          traceId: value.split("=")[1],
+          source: `${header} http header`,
+        };
       }
 
       default: {
@@ -66,7 +76,7 @@ exports.getParentSourceId = (parentIdSource, req) => {
   } else if (typeof traceIdSource === "function") {
     return parentIdSource(req);
   }
-};  
+};
 
 exports.getUserContext = (userContext, req) => {
   if (!userContext) {


### PR DESCRIPTION
Leaving these in enables a problematic situation where if the
full x-amzn-trace-id is set as the trace id, then a downstream
service will only pull out the prefix of the original trace id
(e.g. "Root") and ALL requests will be considered part of a common
trace.

## Background
I believe this addresses this issue: https://github.com/honeycombio/beeline-nodejs/issues/141

## Verification
Unit tests validate specific behavior. If there are concerns I can try and get these changes behind an ELB.