### PR TITLE
Remove entries from previously unbounded maps

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -133,6 +133,8 @@ const instrumentFastify = function(fastify, opts = {}) {
     app.addHook("onResponse", (request, reply, next) => {
       // calculate total time for the request and send the root span
       const finisher = finishersByRequest.get(request);
+      finishersByRequest.delete(request);
+      trackedByRequest.delete(request);
       if (finisher) {
         finisher(reply);
       }


### PR DESCRIPTION
* The request is safe to delete from finishersByRequest because
it is accessed only once, on the previous line, so long as there
is only one 'onResponse' per request.
* The request is safe to delete from trackedByRequest because
onResponse is the last available hook in the lifecycle.

## Verification
I've run this locally and validated using a debugger that these maps don't grow anymore. However I'm not confident enough in my understanding of Fastify hooks/lifecycle to know if there are cases where onResponse is called multiple times for a request, out of order, etc.

It might be worth just adding in some error catching and logging if the deletes fail or entries are missing. 