### PR TITLE
clean up a bunch of span/context related hacks and bugs

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -136,7 +136,7 @@ module.exports = {
         map = { [key]: val };
       }
 
-      return apiImpl.addTraceContext(map);
+      return apiImpl.addTraceContext(mapFieldsToApp(map));
     },
     remove(key) {
       return apiImpl.removeTraceContext(schema.customContext(key));

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -11,6 +11,14 @@ const path = require("path"),
 
 let apiImpl;
 
+function mapFieldsToApp(map) {
+  let mapped = {};
+  for (const k of Object.getOwnPropertyNames(map)) {
+    mapped[schema.customContext(k)] = map[k];
+  }
+  return mapped;
+}
+
 module.exports = {
   configure(opts = {}) {
     if (apiImpl) {
@@ -103,19 +111,44 @@ module.exports = {
     }
   },
 
+  // next major bump should change this to prefix keys with `app.`
   addContext(map) {
     return apiImpl.addContext(map);
   },
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
   removeContext(key) {
     return apiImpl.removeContext(key);
   },
+
+  // DEPRECATED
+  // original api for trace-level (auto-propagated) context.
+  // next major bump will remove this.  No replacement for `.customContext.remove`,
+  // and `.addTraceContext` below will the way to handle `.customContext.add`
   customContext: {
     add(key, val) {
-      apiImpl.addContext({ [schema.customContext(key)]: val });
+      let map;
+
+      if (val === undefined && typeof key === "object") {
+        // key is actually a map, not a string
+        map = {};
+        for (const k of Object.getOwnPropertyNames(key)) {
+          map[schema.customContext(k)] = key[k];
+        }
+      } else {
+        map = { [schema.customContext(key)]: val };
+      }
+
+      return apiImpl.addTraceContext(map);
     },
     remove(key) {
-      apiImpl.removeContext(schema.customContext(key));
+      return apiImpl.removeTraceContext(schema.customContext(key));
     },
+  },
+
+  addTraceContext(map) {
+    return apiImpl.addTraceContext(mapFieldsToApp(map));
   },
 
   // a couple of useful functions for either forcing a function to run within a trace, or

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -131,13 +131,9 @@ module.exports = {
       let map;
 
       if (val === undefined && typeof key === "object") {
-        // key is actually a map, not a string
-        map = {};
-        for (const k of Object.getOwnPropertyNames(key)) {
-          map[schema.customContext(k)] = key[k];
-        }
+        map = key;
       } else {
-        map = { [schema.customContext(key)]: val };
+        map = { [key]: val };
       }
 
       return apiImpl.addTraceContext(map);

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -480,8 +480,6 @@ test("distributed tracing linkage is correct", () => {
 
   let rootContext = tracker.getTracked();
 
-  console.log(rootSpan.payload, rootContext.traceContext);
-
   let marshaledContext = propagation.marshalTraceContext(rootContext);
 
   // this little bit of code simulates a downstream service.

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -493,7 +493,7 @@ test("distributed tracing linkage is correct", () => {
     ctx.parentSpanId
   );
   const subContext = tracker.getTracked();
-  subContext.traceContext = ctx.traceContext;
+  subContext.traceContext = ctx.customContext;
 
   let subserviceSubspan = api.startSpan({
     [schema.TRACE_SPAN_NAME]: "subspan",

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jest */
 const path = require("path"),
-  event = require("."),
+  api = require("."),
   schema = require("../schema"),
   tracker = require("../async_tracker"),
   propagation = require("../propagation"),
@@ -10,11 +10,11 @@ const path = require("path"),
 jest.mock("../deterministic_sampler");
 
 beforeEach(() =>
-  event.configure({ impl: "libhoney-event", transmission: "mock", writeKey: "abc123" })
+  api.configure({ impl: "libhoney-event", transmission: "mock", writeKey: "abc123" })
 );
-afterEach(() => event._resetForTesting());
+afterEach(() => api._resetForTesting());
 test("libhoney default config", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
   expect(honey.transmission.constructorArg.apiHost).toBe("https://api.honeycomb.io");
   expect(honey.transmission.constructorArg.dataset).toBe("nodejs");
   expect(honey.transmission.constructorArg.writeKey).toBe("abc123");
@@ -24,10 +24,10 @@ test("libhoney default config", () => {
 });
 
 test("startTrace starts tracking and creates an initial event, finishTrace sends it", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
   expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
 
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
@@ -36,20 +36,20 @@ test("startTrace starts tracking and creates an initial event, finishTrace sends
   let context = tracker.getTracked();
   expect(context).not.toBeUndefined();
 
-  // the stack consists solely of the request's event
-  expect(context.stack).toEqual([requestPayload]);
+  // the stack consists solely of the root span
+  expect(context.stack).toEqual([rootSpan]);
   // and it should have these properties
-  expect(requestPayload[schema.EVENT_TYPE]).toBe("source");
-  let traceId = requestPayload[schema.TRACE_ID];
+  expect(rootSpan.payload[schema.EVENT_TYPE]).toBe("source");
+  let traceId = rootSpan.payload[schema.TRACE_ID];
   expect(traceId).not.toBeUndefined();
-  let startTime = requestPayload.startTime;
+  let startTime = rootSpan.startTime;
   expect(startTime).not.toBeUndefined();
 
   // libhoney shouldn't have been told to send anything yet
   expect(honey.transmission.events).toEqual([]);
 
   // finish the request
-  event.finishTrace(requestPayload);
+  api.finishTrace(rootSpan);
   expect(tracker.getTracked()).toBeUndefined(); // context should be cleared
 
   // libhoney should have been told to send one event
@@ -67,18 +67,18 @@ test("startTrace starts tracking and creates an initial event, finishTrace sends
 });
 
 test("sample rates are propagated", () => {
-  event._resetForTesting();
-  event.configure({
+  api._resetForTesting();
+  api.configure({
     impl: "libhoney-event",
     transmission: "mock",
     writeKey: "abc123",
     sampleRate: 10,
   });
 
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
   expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
 
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
@@ -88,19 +88,19 @@ test("sample rates are propagated", () => {
   expect(context).not.toBeUndefined();
 
   // the stack consists solely of the request's event
-  expect(context.stack).toEqual([requestPayload]);
+  expect(context.stack).toEqual([rootSpan]);
   // and it should have these properties
-  expect(requestPayload[schema.EVENT_TYPE]).toBe("source");
-  let traceId = requestPayload[schema.TRACE_ID];
+  expect(rootSpan.payload[schema.EVENT_TYPE]).toBe("source");
+  let traceId = rootSpan.payload[schema.TRACE_ID];
   expect(traceId).not.toBeUndefined();
-  let startTime = requestPayload.startTime;
+  let startTime = rootSpan.startTime;
   expect(startTime).not.toBeUndefined();
 
   // libhoney shouldn't have been told to send anything yet
   expect(honey.transmission.events).toEqual([]);
 
   // finish the request
-  event.finishTrace(requestPayload);
+  api.finishTrace(rootSpan);
   expect(tracker.getTracked()).toBeUndefined(); // context should be cleared
 
   // libhoney should have been told to send one event
@@ -124,22 +124,22 @@ describe("sampler hook", () => {
         shouldSample: true,
         sampleRate: 123,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
+      let eventPayload = api.startTrace({});
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(0);
 
-      event.finishTrace(eventPayload);
+      api.finishTrace(eventPayload);
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(1);
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(1);
     });
 
     test("it does not enqueue event if shouldSample is false", () => {
@@ -147,19 +147,19 @@ describe("sampler hook", () => {
         shouldSample: false,
         sampleRate: 123,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(1);
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(0);
     });
 
     test("it does not enqueue event if invalid samplerHook provided", () => {
@@ -167,19 +167,19 @@ describe("sampler hook", () => {
         foo: "bar",
         baz: false,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(1);
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(0);
     });
 
     test("it falls back to deterministicSampler with sampleRate if non-function samplerHook provided", () => {
@@ -189,8 +189,8 @@ describe("sampler hook", () => {
         sampleRate: 999,
       }));
       deterministicSampler.mockImplementation(mockSamplerHook);
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
@@ -198,8 +198,8 @@ describe("sampler hook", () => {
         samplerHook: "I am invalid as I am not a function",
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
       expect(deterministicSampler).toHaveBeenCalledTimes(1);
       expect(deterministicSampler).toHaveBeenCalledWith(12345);
@@ -210,18 +210,18 @@ describe("sampler hook", () => {
         shouldSample: true,
         sampleRate: 999,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
-      expect(event._apiForTesting().honey.transmission.events[0].sampleRate).toEqual(999);
+      expect(api._apiForTesting().honey.transmission.events[0].sampleRate).toEqual(999);
     });
   });
 
@@ -233,21 +233,21 @@ describe("sampler hook", () => {
         sampleRate: 999,
       }));
       deterministicSampler.mockImplementation(mockSamplerHook);
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         sampleRate: 123,
       });
 
-      let eventPayload = event.startTrace();
+      let eventPayload = api.startTrace();
 
       // initialisation
       expect(deterministicSampler).toHaveBeenCalledTimes(1);
       expect(deterministicSampler).toHaveBeenCalledWith(123);
 
-      event.finishTrace(eventPayload);
+      api.finishTrace(eventPayload);
 
       // verify initiliser not called again
       expect(deterministicSampler).toHaveBeenCalledTimes(1);
@@ -258,188 +258,190 @@ describe("sampler hook", () => {
 
   describe("if neither a samplerHook nor sampleRate given", () => {
     test("send all events", () => {
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(1);
     });
   });
 });
 
 test("ending events out of order isn't allowed", () => {
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
   let context = tracker.getTracked();
 
-  expect(context.stack).toEqual([requestPayload]);
+  expect(context.stack).toEqual([rootSpan]);
 
-  let event2Payload = event.startSpan({
+  let span2 = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  let event3Payload = event.startSpan({
+  let span3 = api.startSpan({
     [schema.EVENT_TYPE]: "source3",
     [schema.TRACE_SPAN_NAME]: "name3",
   });
-  expect(context.stack).toEqual([requestPayload, event2Payload, event3Payload]);
+  expect(context.stack).toEqual([rootSpan, span2, span3]);
 
-  // if we end event2Payload from the stack, we should also remove event3Payload.
-  event.finishSpan(event2Payload);
-  expect(context.stack).toEqual([requestPayload]);
+  // if we end span2 from the stack, we should also remove span3.
+  api.finishSpan(span2);
+  expect(context.stack).toEqual([rootSpan]);
 
-  // if we finish event3 now, nothing should happen to the stack
-  event.finishSpan(event3Payload);
-  expect(context.stack).toEqual([requestPayload]);
+  // if we finish span3 now, nothing should happen to the stack
+  api.finishSpan(span3);
+  expect(context.stack).toEqual([rootSpan]);
 });
 
 test("sub-events can opt to rollup count/duration into request events", () => {
-  let requestPayload = event.startTrace({
+  const honey = api._apiForTesting().honey;
+
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
 
-  let eventPayload = event.startSpan({
+  let subSpan = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  event.finishSpan(eventPayload, "rollup");
+  api.finishSpan(subSpan, "rollup");
 
-  let durationMS = eventPayload[schema.DURATION_MS];
-  expect(requestPayload["totals.source2.rollup.count"]).toBe(1);
-  expect(requestPayload["totals.source2.rollup.duration_ms"]).toBe(durationMS);
+  let durationMS = JSON.parse(honey.transmission.events[0].postData)[schema.DURATION_MS];
+  expect(rootSpan.payload["totals.source2.rollup.count"]).toBe(1);
+  expect(rootSpan.payload["totals.source2.rollup.duration_ms"]).toBe(durationMS);
 
-  // another event from the same source
-  let event2Payload = event.startSpan({
+  // another span from the same source
+  let span2 = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  event.finishSpan(event2Payload, "rollup");
+  api.finishSpan(span2, "rollup");
 
-  let duration2MS = event2Payload[schema.DURATION_MS];
-  expect(requestPayload["totals.source2.rollup.count"]).toBe(2);
-  expect(requestPayload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
+  let duration2MS = JSON.parse(honey.transmission.events[1].postData)[schema.DURATION_MS];
+  expect(rootSpan.payload["totals.source2.rollup.count"]).toBe(2);
+  expect(rootSpan.payload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
 
   // these rollup to the instrumentation/source-level as well:
-  expect(requestPayload["totals.source2.count"]).toBe(2);
-  expect(requestPayload["totals.source2.duration_ms"]).toBe(durationMS + duration2MS);
+  expect(rootSpan.payload["totals.source2.count"]).toBe(2);
+  expect(rootSpan.payload["totals.source2.duration_ms"]).toBe(durationMS + duration2MS);
 
   // one more event from the same source but a different name
-  let event3Payload = event.startSpan({
+  let span3 = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
   });
-  event.finishSpan(event3Payload, "rollup2");
+  api.finishSpan(span3, "rollup2");
 
-  let duration3MS = event3Payload[schema.DURATION_MS];
-  expect(requestPayload["totals.source2.rollup2.count"]).toBe(1);
-  expect(requestPayload["totals.source2.rollup2.duration_ms"]).toBe(duration3MS);
+  let duration3MS = JSON.parse(honey.transmission.events[2].postData)[schema.DURATION_MS];
+  expect(rootSpan.payload["totals.source2.rollup2.count"]).toBe(1);
+  expect(rootSpan.payload["totals.source2.rollup2.duration_ms"]).toBe(duration3MS);
 
   // it doesn't touch the "rollup" rollup
-  expect(requestPayload["totals.source2.rollup.count"]).toBe(2);
-  expect(requestPayload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
+  expect(rootSpan.payload["totals.source2.rollup.count"]).toBe(2);
+  expect(rootSpan.payload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
 
   // but it does get rolled into the instrumentation/source-level rollup:
-  expect(requestPayload["totals.source2.count"]).toBe(3);
-  expect(requestPayload["totals.source2.duration_ms"]).toBe(durationMS + duration2MS + duration3MS);
+  expect(rootSpan.payload["totals.source2.count"]).toBe(3);
+  expect(rootSpan.payload["totals.source2.duration_ms"]).toBe(
+    durationMS + duration2MS + duration3MS
+  );
 });
 
 test("sub-events will get manual tracing fields", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
 
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
 
-  let eventPayload = event.startSpan({
+  let subSpan = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  event.finishSpan(eventPayload);
-
-  // finish the request
-  event.finishTrace(requestPayload);
+  api.finishSpan(subSpan);
+  api.finishTrace(rootSpan);
 
   // libhoney should have been told to send two events
   expect(honey.transmission.events.length).toBe(2);
 
-  let subEventData = JSON.parse(honey.transmission.events[0].postData);
-  let reqEventData = JSON.parse(honey.transmission.events[1].postData);
+  let subSpanData = JSON.parse(honey.transmission.events[0].postData);
+  let rootSpanData = JSON.parse(honey.transmission.events[1].postData);
 
-  expect(subEventData[schema.TRACE_PARENT_ID]).toBe(reqEventData[schema.TRACE_SPAN_ID]);
-  expect(subEventData[schema.TRACE_ID]).toBe(reqEventData[schema.TRACE_ID]);
-  expect(subEventData[schema.TRACE_SPAN_NAME]).toBe("name2");
+  expect(subSpanData[schema.TRACE_PARENT_ID]).toBe(rootSpanData[schema.TRACE_SPAN_ID]);
+  expect(subSpanData[schema.TRACE_ID]).toBe(rootSpanData[schema.TRACE_ID]);
+  expect(subSpanData[schema.TRACE_SPAN_NAME]).toBe("name2");
 });
 
 describe("custom context", () => {
   test("it should be added to request events", () => {
-    const honey = event._apiForTesting().honey;
+    const honey = api._apiForTesting().honey;
 
-    let requestPayload = event.startTrace({
+    let requestPayload = api.startTrace({
       [schema.EVENT_TYPE]: "source",
       [schema.TRACE_SPAN_NAME]: "name",
     });
 
-    event.customContext.add("testKey", "testVal");
+    api.customContext.add("testKey", "testVal");
 
     // finish the request
-    event.finishTrace(requestPayload);
+    api.finishTrace(requestPayload);
 
     let requestData = JSON.parse(honey.transmission.events[0].postData);
     expect(requestData[schema.customContext("testKey")]).toBe("testVal");
   });
 
   test("removing it works too", () => {
-    const honey = event._apiForTesting().honey;
+    const honey = api._apiForTesting().honey;
 
-    let requestPayload = event.startTrace({
+    let requestPayload = api.startTrace({
       [schema.EVENT_TYPE]: "source",
       [schema.TRACE_SPAN_NAME]: "name",
     });
 
-    event.customContext.add("testKey", "testVal");
+    api.customContext.add("testKey", "testVal");
 
-    event.customContext.remove("testKey");
+    api.customContext.remove("testKey");
 
     // finish the request
-    event.finishTrace(requestPayload);
+    api.finishTrace(requestPayload);
 
     let requestData = JSON.parse(honey.transmission.events[0].postData);
     expect(requestData[schema.customContext("testKey")]).toBeUndefined();
   });
 
   test("it should be added to subevents sent after it was added", () => {
-    const honey = event._apiForTesting().honey;
+    const honey = api._apiForTesting().honey;
 
-    let requestPayload = event.startTrace({
+    let requestPayload = api.startTrace({
       [schema.EVENT_TYPE]: "source",
       [schema.TRACE_SPAN_NAME]: "name",
     });
 
-    let eventPayload = event.startSpan({
+    let eventPayload = api.startSpan({
       [schema.EVENT_TYPE]: "source2",
       [schema.TRACE_SPAN_NAME]: "name2",
     });
-    event.finishSpan(eventPayload);
+    api.finishSpan(eventPayload);
 
-    event.customContext.add("testKey", "testVal");
+    api.customContext.add("testKey", "testVal");
 
-    let eventPayload2 = event.startSpan({
+    let eventPayload2 = api.startSpan({
       [schema.EVENT_TYPE]: "source3",
       [schema.TRACE_SPAN_NAME]: "name3",
     });
-    event.finishSpan(eventPayload2);
+    api.finishSpan(eventPayload2);
 
     // finish the request
-    event.finishTrace(requestPayload);
+    api.finishTrace(requestPayload);
 
     // libhoney should have been told to send two events
     expect(honey.transmission.events.length).toBe(3);
@@ -463,38 +465,48 @@ describe("custom context", () => {
 });
 
 test("distributed tracing linkage is correct", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
 
-  let rootSpan = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.TRACE_SPAN_NAME]: "root",
   });
-  let traceId = rootSpan[schema.TRACE_ID];
+  let traceId = rootSpan.payload[schema.TRACE_ID];
+
+  // add some additional context to the root span
+  rootSpan.addContext({ directContext: "direct" });
+  api.addContext({ localContext: "local" });
+  api.customContext.add({ customContext: "custom" });
+  api.addTraceContext({ traceCustomContext: "trace-custom" });
 
   let rootContext = tracker.getTracked();
+
+  console.log(rootSpan.payload, rootContext.traceContext);
 
   let marshaledContext = propagation.marshalTraceContext(rootContext);
 
   // this little bit of code simulates a downstream service.
   tracker.setTracked(undefined);
   let ctx = propagation.unmarshalTraceContext(marshaledContext);
-  let subserviceRootSpan = event.startTrace(
+  let subserviceRootSpan = api.startTrace(
     {
       [schema.TRACE_SPAN_NAME]: "sub",
     },
     ctx.traceId,
     ctx.parentSpanId
   );
+  const subContext = tracker.getTracked();
+  subContext.traceContext = ctx.traceContext;
 
-  let subserviceSubspan = event.startSpan({
+  let subserviceSubspan = api.startSpan({
     [schema.TRACE_SPAN_NAME]: "subspan",
   });
-  event.finishSpan(subserviceSubspan);
-  event.finishTrace(subserviceRootSpan);
+  api.finishSpan(subserviceSubspan);
+  api.finishTrace(subserviceRootSpan);
   // end of downstream service.
 
   // reinstate the root service's context and finish the trace there.
   tracker.setTracked(rootContext);
-  event.finishTrace(rootSpan);
+  api.finishTrace(rootSpan);
 
   // libhoney should have been told to send three events
   expect(honey.transmission.events.length).toBe(3);
@@ -523,21 +535,38 @@ test("distributed tracing linkage is correct", () => {
   s.add(subTraceEventData[schema.TRACE_SPAN_ID]);
   s.add(rootEventData[schema.TRACE_SPAN_ID]);
   expect(s.size).toBe(3);
+
+  // verify that context was/was not propagated
+  expect(rootEventData["directContext"]).toBe("direct");
+  expect(subSpanEventData["directContext"]).toBeUndefined();
+  expect(subTraceEventData["directContext"]).toBeUndefined();
+
+  expect(rootEventData["localContext"]).toBe("local");
+  expect(subSpanEventData["localContext"]).toBeUndefined();
+  expect(subTraceEventData["localContext"]).toBeUndefined();
+
+  expect(rootEventData["app.customContext"]).toBe("custom");
+  expect(subSpanEventData["app.customContext"]).toBe("custom");
+  expect(subTraceEventData["app.customContext"]).toBe("custom");
+
+  expect(rootEventData["app.traceCustomContext"]).toBe("trace-custom");
+  expect(subSpanEventData["app.traceCustomContext"]).toBe("trace-custom");
+  expect(subTraceEventData["app.traceCustomContext"]).toBe("trace-custom");
 });
 
 test("async spans share custom context", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
 
-  let rootSpan = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.TRACE_SPAN_NAME]: "root",
   });
 
-  event.customContext.add("custom", "value");
+  api.customContext.add("custom", "value");
 
-  event.startAsyncSpan({}, span => {
-    event.finishSpan(span);
+  api.startAsyncSpan({}, span => {
+    api.finishSpan(span);
   });
-  event.finishTrace(rootSpan);
+  api.finishTrace(rootSpan);
 
   expect(honey.transmission.events.length).toBe(2);
 
@@ -548,27 +577,27 @@ test("async spans share custom context", () => {
 describe("presend hook", () => {
   it("calls the presend hook function if provided", () => {
     const mockPresendHook = jest.fn();
-    event._resetForTesting();
-    event.configure({
+    api._resetForTesting();
+    api.configure({
       impl: "libhoney-event",
       transmission: "mock",
       writeKey: "abc123",
       presendHook: mockPresendHook,
     });
 
-    let eventPayload = event.startTrace({});
+    let eventPayload = api.startTrace({});
 
-    event.finishTrace(eventPayload);
+    api.finishTrace(eventPayload);
 
     expect(mockPresendHook).toHaveBeenCalledTimes(1);
-    expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+    expect(api._apiForTesting().honey.transmission.events).toHaveLength(1);
   });
 
   it("doesn't call the presend hook if the event is not being sampled", () => {
     const mockPresendHook = jest.fn();
     const mockSamplerHook = jest.fn(() => ({ shouldSample: false, sampleRate: 1 }));
-    event._resetForTesting();
-    event.configure({
+    api._resetForTesting();
+    api.configure({
       impl: "libhoney-event",
       transmission: "mock",
       writeKey: "abc123",
@@ -576,12 +605,12 @@ describe("presend hook", () => {
       presendHook: mockPresendHook,
     });
 
-    let eventPayload = event.startTrace({});
+    let eventPayload = api.startTrace({});
 
-    event.finishTrace(eventPayload);
+    api.finishTrace(eventPayload);
 
     expect(mockSamplerHook).toHaveBeenCalledTimes(1);
     expect(mockPresendHook).toHaveBeenCalledTimes(0);
-    expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+    expect(api._apiForTesting().honey.transmission.events).toHaveLength(0);
   });
 });

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -9,6 +9,7 @@ const libhoney = require("libhoney"),
   instrumentation = require("../instrumentation"),
   deterministicSampler = require("../deterministic_sampler"),
   schema = require("../schema"),
+  Span = require("./span"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
   debug = require("debug")(`${pkg.name}:event`);
 
@@ -94,15 +95,15 @@ module.exports = class LibhoneyEventAPI {
 
     tracker.setTracked({
       id,
-      customContext: {},
+      traceContext: {},
       stack: [],
       dataset: dataset || this.defaultDataset,
     });
     return this.startSpan(metadataContext, undefined, parentSpanId);
   }
 
-  finishTrace(ev) {
-    this.finishSpan(ev);
+  finishTrace(span) {
+    this.finishSpan(span);
     tracker.deleteTracked();
   }
 
@@ -117,23 +118,23 @@ module.exports = class LibhoneyEventAPI {
       if (parentId) {
         debug("parentId supplied when there are already spans.. wrong.");
       }
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+      parentId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
     }
     if (!parentId) {
       parentId = context.parentId;
     }
 
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: context.id,
-      [schema.TRACE_SPAN_ID]: spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: context.id,
+        [schema.TRACE_SPAN_ID]: spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
-    context.stack.push(eventPayload);
-    return eventPayload;
+    context.stack.push(span);
+    return span;
   }
 
   startAsyncSpan(metadataContext, spanFn) {
@@ -153,29 +154,29 @@ module.exports = class LibhoneyEventAPI {
       parentId = parentContext.parentId;
     }
 
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: parentContext.id,
-      [schema.TRACE_SPAN_ID]: spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: parentContext.id,
+        [schema.TRACE_SPAN_ID]: spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
 
     let newContext = {
       id: parentContext.id,
       parentId: parentId,
-      customContext: parentContext.customContext,
+      traceContext: parentContext.traceContext,
       dataset: parentContext.dataset,
-      stack: [eventPayload],
+      stack: [span],
     };
 
-    return tracker.callWithContext(() => spanFn(eventPayload), newContext);
+    return tracker.callWithContext(() => spanFn(span), newContext);
   }
 
-  finishSpan(ev, rollup) {
-    debug(`finishing span ${JSON.stringify(ev)}`);
+  finishSpan(span, rollup) {
+    debug(`finishing span ${JSON.stringify(span)}`);
     const context = tracker.getTracked();
     if (!context) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
@@ -184,30 +185,23 @@ module.exports = class LibhoneyEventAPI {
     }
     if (context.stack.length === 0) {
       // this _really_ shouldn't happen.
-      this.askForIssue("no payload for event we're trying to finish (stack is empty).");
+      this.askForIssue("no payload for span we're trying to finish (stack is empty).");
       return;
     }
-    const idx = context.stack.indexOf(ev);
+    const idx = context.stack.indexOf(span);
     if (idx === -1) {
       // again, this _really_ shouldn't happen.
-      this.askForIssue("no payload for event we're trying to finish (event not found).");
+      this.askForIssue("no payload for span we're trying to finish (span not found).");
       return;
     }
     if (idx !== context.stack.length - 1) {
       // the event we're finishing isn't the most deeply nested one. warn the user.
       this.askForIssue(
-        "finishing an event with unfinished nested events. almost certainly not what we want."
+        "finishing an span with unfinished nested spans. almost certainly not what we want."
       );
     }
 
-    const payload = context.stack[idx];
-
-    const { startTime, startTimeHR } = payload;
-    const duration = process.hrtime(startTimeHR);
-    const durationMs = (duration[0] * 1e9 + duration[1]) / 1e6;
-    payload[schema.DURATION_MS] = durationMs;
-    delete payload.startTime;
-    delete payload.startTimeHR;
+    const payload = context.stack[idx].finalizePayload();
 
     // chop off events after (and including) this one from the stack.
     context.stack = context.stack.slice(0, idx);
@@ -218,16 +212,16 @@ module.exports = class LibhoneyEventAPI {
         if (context.stack.length === 0) {
           debug("no event to rollup into");
         } else {
-          const rootPayload = context.stack[0];
+          const rootPayload = context.stack[0].payload;
           const type = payload[schema.EVENT_TYPE];
 
           // per-rollup rollups
           incr(rootPayload, `totals.${type}.${rollup}.count`);
-          incr(rootPayload, `totals.${type}.${rollup}.duration_ms`, durationMs);
+          incr(rootPayload, `totals.${type}.${rollup}.duration_ms`, payload[schema.DURATION_MS]);
 
           // per-instrumentation rollups
           incr(rootPayload, `totals.${type}.count`);
-          incr(rootPayload, `totals.${type}.duration_ms`, durationMs);
+          incr(rootPayload, `totals.${type}.duration_ms`, payload[schema.DURATION_MS]);
         }
       }
 
@@ -235,9 +229,9 @@ module.exports = class LibhoneyEventAPI {
       const active_instrumentation_count = active_instrumentations.length;
       const ev = this.honey.newEvent();
       ev.dataset = context.dataset;
-      ev.timestamp = new Date(startTime);
+      ev.timestamp = new Date(span.startTime);
       ev.add(payload);
-      ev.add(context.customContext);
+      ev.add(context.traceContext);
       ev.add({
         [schema.INSTRUMENTATIONS]: active_instrumentations,
         [schema.INSTRUMENTATION_COUNT]: active_instrumentation_count,
@@ -271,20 +265,42 @@ module.exports = class LibhoneyEventAPI {
 
   addContext(map) {
     const context = tracker.getTracked();
-    if (!context) {
+    if (!context || context.stack.length === 0) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    Object.assign(context.customContext, map);
+    Object.assign(context.stack[0].payload, map);
   }
 
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
   removeContext(key) {
+    const context = tracker.getTracked();
+    if (!context || context.stack.length === 0) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
+      return;
+    }
+    delete context.stack[0].payload[key];
+  }
+
+  addTraceContext(map) {
     const context = tracker.getTracked();
     if (!context) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    delete context.customContext[key];
+    Object.assign(context.traceContext, map);
+  }
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
+  removeTraceContext(key) {
+    const context = tracker.getTracked();
+    if (!context) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
+      return;
+    }
+    delete context.traceContext[key];
   }
 
   dumpRequestContext() {

--- a/lib/api/mock.js
+++ b/lib/api/mock.js
@@ -1,14 +1,14 @@
 /* eslint-env node */
-const process = require("process"),
-  path = require("path"),
+const path = require("path"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
   tracker = require("../async_tracker"),
-  schema = require("../schema");
+  schema = require("../schema"),
+  Span = require("./span");
 
 module.exports = class MockEventAPI {
   constructor(opts) {
     this.constructorArg = opts;
-    this.customContext = {};
+    this.traceContext = {};
     this.sentEvents = [];
     this.traceId = 0;
   }
@@ -25,63 +25,82 @@ module.exports = class MockEventAPI {
   startSpan(metadataContext, spanId = undefined, parentId = undefined) {
     let context = tracker.getTracked();
     if (context.stack.length > 0) {
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+      parentId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
     }
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: context.id,
-      [schema.TRACE_SPAN_ID]: spanId || ++context.spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: context.id,
+        [schema.TRACE_SPAN_ID]: spanId || ++context.spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
-    context.stack.push(eventPayload);
-    return eventPayload;
+    context.stack.push(span);
+    return span;
   }
   startAsyncSpan(metadataContext, spanFn) {
     let parentId;
     let context = tracker.getTracked();
     let spanId = context.spanId + 1000;
     if (context.stack.length > 0) {
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+      parentId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
     }
 
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: context.id,
-      [schema.TRACE_SPAN_ID]: ++spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: context.id,
+        [schema.TRACE_SPAN_ID]: ++spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
 
     let newContext = {
       id: context.id,
       spanId,
-      stack: [eventPayload],
+      stack: [span],
     };
 
-    return tracker.callWithContext(() => spanFn(eventPayload), newContext);
+    return tracker.callWithContext(() => spanFn(span), newContext);
   }
 
-  finishSpan(ev, _rollup) {
-    Object.assign(ev, this.customContext, {
-      [schema.DURATION_MS]: 0,
-      [schema.BEELINE_VERSION]: pkg.version,
-    });
+  finishSpan(span, _rollup) {
+    const payload = span.finalizePayload();
+
+    // override this so we don't have to worry about test durations
+    payload[schema.DURATION_MS] = 0;
+
+    payload[schema.BEELINE_VERSION] = pkg.version;
+
     let context = tracker.getTracked();
     // pop it off the stack
-    const idx = context.stack.indexOf(ev);
+    const idx = context.stack.indexOf(span);
     this.eventStack = context.stack.slice(0, idx);
-    this.sentEvents.push(ev);
+    this.sentEvents.push(payload);
   }
+
   addContext(map) {
-    Object.assign(this.customContext, map);
+    let context = tracker.getTracked();
+    Object.assign(context.stack[0], map);
   }
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
   removeContext(key) {
-    delete this.customContext[key];
+    let context = tracker.getTracked();
+    delete context.stack[0].payload[key];
+  }
+
+  addTraceContext(map) {
+    Object.assign(this.traceContext, map);
+  }
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
+  removeTraceContext(key) {
+    delete this.traceContext[key];
   }
 
   flush() {

--- a/lib/api/span.js
+++ b/lib/api/span.js
@@ -1,0 +1,23 @@
+/* eslint-env node */
+const process = require("process"),
+  schema = require("../schema");
+
+module.exports = class Span {
+  constructor(payload) {
+    this.payload = payload;
+    this.startTime = Date.now();
+    this.startTimeHR = process.hrtime();
+  }
+
+  addContext(map) {
+    Object.assign(this.payload, map);
+  }
+
+  finalizePayload() {
+    let rv = Object.assign({}, this.payload);
+    const duration = process.hrtime(this.startTimeHR);
+    const durationMs = (duration[0] * 1e9 + duration[1]) / 1e6;
+    rv[schema.DURATION_MS] = durationMs;
+    return rv;
+  }
+};

--- a/lib/instrumentation/child_process.js
+++ b/lib/instrumentation/child_process.js
@@ -19,7 +19,7 @@ function wrapExecLike(name, packageVersion) {
         },
         span => {
           if (Array.isArray(args)) {
-            api.addContext({ "exec.args": args });
+            span.addContext({ "exec.args": args });
           }
 
           let argsArray = Array.from(arguments);

--- a/lib/instrumentation/child_process.test.js
+++ b/lib/instrumentation/child_process.test.js
@@ -36,6 +36,7 @@ test("execFile '/bin/echo hi' works", done => {
   child_process.execFile("echo", ["hi"], (error, stdout) => {
     expect(error).toBeNull();
     expect(stdout).toBe("hi\n");
+
     expect(api._apiForTesting().sentEvents.length).toBe(1);
 
     let ev = api._apiForTesting().sentEvents[0];

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -88,7 +88,7 @@ const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packag
   if (parentTraceId) {
     traceContext.parentSpanId = parentTraceId;
   }
-  let trace = api.startTrace(
+  let rootSpan = api.startTrace(
     {
       [schema.EVENT_TYPE]: "express",
       [schema.PACKAGE_VERSION]: packageVersion,
@@ -112,10 +112,10 @@ const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packag
   );
 
   if (traceContext.customContext) {
-    api.addContext(traceContext.customContext);
+    api.addTraceContext(traceContext.customContext);
   }
 
-  if (!trace) {
+  if (!rootSpan) {
     // sampler has decided that we shouldn't trace this request
     next();
     return;
@@ -131,27 +131,27 @@ const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packag
 
     let userEventContext = traceUtil.getUserContext(userContext, req);
     if (userEventContext) {
-      api.addContext(userEventContext);
+      rootSpan.addContext(userEventContext);
     }
 
-    api.addContext({
+    rootSpan.addContext({
       "request.base_url": req.baseUrl,
       "response.status_code": String(response.statusCode),
     });
     if (req.route) {
-      api.addContext({
+      rootSpan.addContext({
         "request.route": req.route.path,
       });
     }
     if (req.params) {
       Object.keys(req.params).forEach(param =>
-        api.addContext({
+        rootSpan.addContext({
           [`request.param.${param}`]: req.params[param],
         })
       );
     }
 
-    api.finishTrace(trace);
+    api.finishTrace(rootSpan);
   });
 
   onHeaders(res, function() {

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -38,10 +38,6 @@ describe("userContext", () => {
       .expect(200, () => {
         expect(api._apiForTesting().sentEvents.length).toBe(1);
         let ev = api._apiForTesting().sentEvents[0];
-        expect(ev.startTime).not.toBeUndefined();
-        expect(ev.startTimeHR).not.toBeUndefined();
-        delete ev.startTime;
-        delete ev.startTimeHR;
         expect(ev).toEqual(
           expect.objectContaining({
             [schema.TRACE_ID]: 0,

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -75,7 +75,7 @@ const instrumentFastify = function(fastify, opts = {}) {
       if (parentTraceId) {
         traceContext.parentSpanId = parentTraceId;
       }
-      let trace = api.startTrace(
+      let rootSpan = api.startTrace(
         {
           [schema.EVENT_TYPE]: "fastify",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
@@ -95,10 +95,10 @@ const instrumentFastify = function(fastify, opts = {}) {
       );
 
       if (traceContext.customContext) {
-        api.addContext(traceContext.customContext);
+        api.addTraceContext(traceContext.customContext);
       }
 
-      if (!trace) {
+      if (!rootSpan) {
         // sampler has decided that we shouldn't trace this request
         next();
         return;
@@ -107,21 +107,21 @@ const instrumentFastify = function(fastify, opts = {}) {
       const boundFinisher = api.bindFunctionToTrace(reply => {
         let userEventContext = traceUtil.getUserContext(userContext, request);
         if (userEventContext) {
-          api.addContext(userEventContext);
+          rootSpan.addContext(userEventContext);
         }
 
-        api.addContext({
+        rootSpan.addContext({
           "response.status_code": String(reply.res.statusCode),
         });
         if (request.params) {
           Object.keys(request.params).forEach(param =>
-            api.addContext({
+            rootSpan.addContext({
               [`request.param.${param}`]: request.params[param],
             })
           );
         }
 
-        api.finishTrace(trace);
+        api.finishTrace(rootSpan);
       });
 
       finishersByRequest.set(request, boundFinisher);

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -36,16 +36,6 @@ describe("userContext", () => {
           const sentEvents = api._apiForTesting().sentEvents;
           expect(sentEvents.length).toBe(2);
 
-          expect(sentEvents[0].startTime).not.toBeUndefined();
-          expect(sentEvents[0].startTimeHR).not.toBeUndefined();
-          delete sentEvents[0].startTime;
-          delete sentEvents[0].startTimeHR;
-
-          expect(sentEvents[1].startTime).not.toBeUndefined();
-          expect(sentEvents[1].startTimeHR).not.toBeUndefined();
-          delete sentEvents[1].startTime;
-          delete sentEvents[1].startTimeHR;
-
           expect(sentEvents).toEqual(
             expect.arrayContaining([
               expect.objectContaining({

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -51,13 +51,15 @@ function instrumentMongodb(mongodb, opts = {}) {
           },
           span => {
             if (options) {
-              api.addContext(prefixKeys("db.options", {
-                ...options,
-                session: undefined,
-              }));
+              span.addContext(
+                prefixKeys("db.options", {
+                  ...options,
+                  session: undefined,
+                })
+              );
             }
             if (additionalContext) {
-              api.addContext(prefixKeys("db", additionalContext(...populatedArgs)));
+              span.addContext(prefixKeys("db", additionalContext(...populatedArgs)));
             }
 
             if (callback) {
@@ -78,7 +80,7 @@ function instrumentMongodb(mongodb, opts = {}) {
                 },
                 err => {
                   if (err) {
-                    api.addContext({ error: err.toString() });
+                    span.addContext({ error: err.toString() });
                   }
                   api.finishSpan(span, eventName);
                 }

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -35,7 +35,7 @@ const wrapper = (span, cb) => {
     const [error, result] = cb_args;
 
     if (error !== null && error instanceof Error) {
-      api.addContext({
+      span.addContext({
         "db.error": error.message,
         "db.error_stack": error.stack,
         "db.error_hint": error.hint,
@@ -43,7 +43,7 @@ const wrapper = (span, cb) => {
     }
 
     if (result) {
-      api.addContext({
+      span.addContext({
         "db.rows_affected": result.rowCount,
       });
     }

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -66,7 +66,7 @@ exports.getParentSourceId = (parentIdSource, req) => {
   } else if (typeof traceIdSource === "function") {
     return parentIdSource(req);
   }
-};  
+};
 
 exports.getUserContext = (userContext, req) => {
   if (!userContext) {

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -89,15 +89,15 @@ function unmarshalTraceContextv1(payload) {
     return;
   }
 
-  let traceContext;
+  let customContext;
   if (contextb64) {
     try {
-      traceContext = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
+      customContext = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
     } catch (e) {
       debug("couldn't decode context", e);
       return;
     }
   }
 
-  return { traceId, parentSpanId, traceContext, dataset };
+  return { traceId, parentSpanId, customContext, dataset };
 }

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -26,11 +26,11 @@ exports.VERSION = VERSION;
 // ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
 
 exports.marshalTraceContext = marshalTraceContextv1;
-function marshalTraceContextv1(traceContext) {
-  let traceId = traceContext.id;
-  let spanId = traceContext.stack[traceContext.stack.length - 1][schema.TRACE_SPAN_ID];
-  let contextToSend = traceContext.customContext || {};
-  let dataset = traceContext.dataset;
+function marshalTraceContextv1(context) {
+  let traceId = context.id;
+  let spanId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
+  let contextToSend = context.traceContext || {};
+  let dataset = context.dataset;
 
   let datasetClause = "";
   if (dataset) {
@@ -89,15 +89,15 @@ function unmarshalTraceContextv1(payload) {
     return;
   }
 
-  let customContext;
+  let traceContext;
   if (contextb64) {
     try {
-      customContext = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
+      traceContext = JSON.parse(Buffer.from(contextb64, "base64").toString("ascii"));
     } catch (e) {
       debug("couldn't decode context", e);
       return;
     }
   }
 
-  return { traceId, parentSpanId, customContext, dataset };
+  return { traceId, parentSpanId, traceContext, dataset };
 }

--- a/lib/propagation.test.js
+++ b/lib/propagation.test.js
@@ -75,7 +75,7 @@ describe("roundtrip", () => {
       traceId: "abcdef123456",
       parentSpanId: "0102030405",
       dataset: "testDataset",
-      traceContext: {
+      customContext: {
         userID: 1,
         errorMsg: "failed to sign on",
         toRetry: true,

--- a/lib/propagation.test.js
+++ b/lib/propagation.test.js
@@ -1,14 +1,15 @@
 /* global require describe test expect */
 const propagation = require("./propagation"),
   schema = require("./schema"),
+  Span = require("./api/span"),
   cases = require("jest-in-case");
 
 // this context structure is the same as what the libhoney event api implementation generate.
 let testContext = {
   id: "abcdef123456",
   dataset: "testDataset",
-  stack: [{ [schema.TRACE_SPAN_ID]: "0102030405" }],
-  customContext: {
+  stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
+  traceContext: {
     userID: 1,
     errorMsg: "failed to sign on",
     toRetry: true,
@@ -74,7 +75,7 @@ describe("roundtrip", () => {
       traceId: "abcdef123456",
       parentSpanId: "0102030405",
       dataset: "testDataset",
-      customContext: {
+      traceContext: {
         userID: 1,
         errorMsg: "failed to sign on",
         toRetry: true,


### PR DESCRIPTION
A few things changed here - one thing in a backward incompatible way _but_ in a way consistent with our docs.

1. Introduce a `Span` class, and change the api implementations to use instances of `Span` instead of regular JS objects in their `context.stack`.
2. `Span` exposes an `addContext` method that acts similar to the go beeline's -- no prefixing of `app.` when using it.  Change all instrumentation to call this method directly, since we always have a span there.
3. `Span` also has fields for `startTime`/`startTimeHR` so all the handling of those fields can be cleaned up - no more `delete`ing them from the payload when we send (and in tests!  ugh.)
3. Add a toplevel `addTraceContext` api method that acts similar to the go beeline's -- prefix with `app.` and also propagates to outbound http/https.
4. The backward incompatible change alluded to above: `api.addContext` no longer results in that context being propagated to outbound calls.  This is the documented behavior, so I don't feel as bad about making this change.

Now for the good stuff.  This PR also marks some things as deprecated or to-be-changed with the next major bump:

1. `api.customContext.{add, remove}` goes away entirely.  `.add` is the same as `api.addTraceContext`.  there is no replacement for `.remove`
2. similarly, `api.removeContext` goes away without replacement.
3. `api.addContext` will prefix with `app.`.  This mirrors the go beeline - if you have direct reference to a span you can call `span.addContext` and it won't prepend `app.`.  If you call the toplevel `addContext`, it will.

Added some more tests that exercise the various context adding methods so we'll fail those if we have regressions again in any of the documented behavior.

Fixes #149 
Fixes #156 
maybe others...