### PR TITLE
split('=') needs max=2 or we break base64 encoded context with padding

### DIFF
--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -59,7 +59,7 @@ function unmarshalTraceContextv1(payload) {
   let traceId, parentSpanId, dataset, contextb64;
 
   clauses.forEach(cl => {
-    let [k, v] = cl.split("=");
+    let [k, v] = cl.split("=", 2);
     switch (k) {
       case "trace_id":
         traceId = v;

--- a/lib/propagation.test.js
+++ b/lib/propagation.test.js
@@ -64,6 +64,17 @@ cases(
         parentSpanId: "12345",
       },
     },
+    {
+      name: "v1, with context",
+      contextStr: "1;trace_id=abcdef,parent_id=12345,context=eyJmb28iOiJiYXIifQo=",
+      value: {
+        traceId: "abcdef",
+        parentSpanId: "12345",
+        customContext: {
+          foo: "bar",
+        },
+      },
+    },
   ]
 );
 


### PR DESCRIPTION
Fixes #190 

Splitting `k=v` strings by `=` fails if `v` contains an `=`, which is quite likely given that we're base64 encoding our trace `context`.  use `.split("=", 2)` to fix.
