### PR TITLE
Make non-Honeycomb header trace parsing opt-in.

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -50,6 +50,8 @@ module.exports = {
   },
 
   TRACE_HTTP_HEADER: propagation.TRACE_HTTP_HEADER,
+  AMAZON_HTTP_HEADER: propagation.AMAZON_HTTP_HEADER,
+  REQUEST_ID_HEADER: propagation.REQUEST_ID_HEADER,
   marshalTraceContext: propagation.marshalTraceContext,
   unmarshalTraceContext: propagation.unmarshalTraceContext,
 

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -129,7 +129,7 @@ describe("userContext as function", () => {
   });
 });
 
-describe("req proprties should only be read after a request matches a route", () => {
+describe("req properties should only be read after a request matches a route", () => {
   const express = instrumentExpress(require("express"), {});
 
   let server;
@@ -185,8 +185,8 @@ describe("req proprties should only be read after a request matches a route", ()
   });
 });
 
-describe("request id from http headers", () => {
-  const express = instrumentExpress(require("express"), {});
+describe("request id from x-request-id http header", () => {
+  const express = instrumentExpress(require("express"), { traceIdSource: "X-Request-ID" });
 
   let server;
   function initializeTestServer() {
@@ -220,6 +220,30 @@ describe("request id from http headers", () => {
         done();
       });
   });
+});
+
+describe("Trace ids from X-Amzn-trace-id header", () => {
+  const express = instrumentExpress(require("express"), { traceIdSource: "X-Amzn-Trace-Id" });
+
+  let server;
+  function initializeTestServer() {
+    let app = express();
+    app.get("/", function(req, res) {
+      // don't add req.user here
+      res.status(200).send("ok");
+    });
+
+    server = app.listen(3000);
+  }
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+    initializeTestServer();
+  });
+  afterEach(() => {
+    api._resetForTesting();
+    server.close();
+  });
 
   test("X-Amzn-Trace-Id works", done => {
     request(server)
@@ -232,6 +256,30 @@ describe("request id from http headers", () => {
         expect(ev[schema.TRACE_ID_SOURCE]).toBe("X-Amzn-Trace-Id http header");
         done();
       });
+  });
+});
+
+describe("Trace ids from X-Request-ID and X-Amzn-trace-id headers", () => {
+  const express = instrumentExpress(require("express"), { traceIdSource: "X-Request-ID" });
+
+  let server;
+  function initializeTestServer() {
+    let app = express();
+    app.get("/", function(req, res) {
+      // don't add req.user here
+      res.status(200).send("ok");
+    });
+
+    server = app.listen(3000);
+  }
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+    initializeTestServer();
+  });
+  afterEach(() => {
+    api._resetForTesting();
+    server.close();
   });
 
   test("X-Request-ID > X-Amzn-Trace-Id", done => {

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -81,12 +81,14 @@ describe("userContext", () => {
       name: "field array userContext",
       userContext: ["id", "username"],
       packageVersion: "1.1.1",
+      traceIdSource: "X-Request-ID",
     },
 
     {
       description: "function userContext",
       userContext: req => ({ id: req.user.id, username: req.user.username }),
       packageVersion: "1.1.1",
+      traceIdSource: "X-Request-ID",
     },
   ]);
 });
@@ -132,7 +134,7 @@ describe("userContext as function", () => {
 
 describe("request id from http headers", () => {
   function runCase(opts, done) {
-    const fastify = instrumentFastify(require("fastify"));
+    const fastify = instrumentFastify(require("fastify"), { traceIdSource: opts.traceIdSource });
     expect(fastify.__wrapped).toBe(true);
 
     function initializeTestServer() {
@@ -179,15 +181,15 @@ describe("request id from http headers", () => {
       headers: [{ name: "X-Request-ID", value: "abc123" }],
       expectedHeaderName: "X-Request-ID",
       expectedHeaderValue: "abc123",
+      traceIdSource: "X-Request-ID",
     },
-
     {
       name: "X-Request-ID works",
       headers: [{ name: "X-Amzn-Trace-Id", value: "Root=1-67891233-abcdef012345678912345678" }],
       expectedHeaderName: "X-Amzn-Trace-Id",
       expectedHeaderValue: "1-67891233-abcdef012345678912345678",
+      traceIdSource: "X-Amzn-Trace-Id",
     },
-
     {
       name: "X-Request-ID > X-Amzn-Trace-Id",
       headers: [
@@ -196,6 +198,7 @@ describe("request id from http headers", () => {
       ],
       expectedHeaderName: "X-Request-ID",
       expectedHeaderValue: "abc123",
+      traceIdSource: "X-Request-ID",
     },
   ]);
 });

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -21,13 +21,11 @@ const getValueFromHeaders = (requestHeaders, headers) => {
   return undefined;
 };
 
-const X_AMZN_TRACE_ID_HEADER = "X-Amzn-Trace-Id";
-
 exports.getTraceContext = (traceIdSource, req) => {
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
       typeof traceIdSource === "undefined"
-        ? [api.TRACE_HTTP_HEADER, "X-Request-ID", X_AMZN_TRACE_ID_HEADER]
+        ? [api.TRACE_HTTP_HEADER]
         : [traceIdSource];
     let valueAndHeader = getValueFromHeaders(req.headers, headers);
 
@@ -47,7 +45,7 @@ exports.getTraceContext = (traceIdSource, req) => {
         });
       }
 
-      case X_AMZN_TRACE_ID_HEADER: {
+      case api.AMAZON_HTTP_HEADER: {
         let traceId, parentSpanId;
 
         const split = value.split(";");

--- a/lib/instrumentation/trace-util.test.js
+++ b/lib/instrumentation/trace-util.test.js
@@ -16,7 +16,7 @@ describe("getTraceContext", () => {
     opts => {
       expect(
         traceUtil.getTraceContext(
-          undefined,
+          "X-Amzn-Trace-Id",
           getRequestWithHeader("X-Amzn-Trace-Id", opts.headerVal)
         )
       ).toEqual(opts.expectedContext);

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -4,7 +4,9 @@ const path = require("path"),
   debug = require("debug")(`${pkg.name}:propagation`),
   schema = require("./schema");
 
-exports.TRACE_HTTP_HEADER = "X-Honeycomb-Trace";
+exports.TRACE_HTTP_HEADER  = "X-Honeycomb-Trace";
+exports.AMAZON_HTTP_HEADER = "X-Amzn-Trace-Id";
+exports.REQUEST_ID_HEADER  = "X-Request-ID";
 
 const VERSION = "1";
 exports.VERSION = VERSION;


### PR DESCRIPTION
Before this change, we've been automatically parsing incoming Amazon
trace ID headers, and recently we started using the extracted values to
set trace.trace_id and trace.parent_id. This is potentially surprising
to users who are not using honeyaws to parse their ALB or ELB logs and
send the data to the same dataset, in that they'd get traces with
missing root spans.

This change requires that users of the node beeline specify the trace
source in the beeline initialization, e.g.:

```
require("honeycomb-beeline")({
    writeKey:    "foo",
    dataset:     "bar",
    serviceName: "foo-service",
    express: {
        traceIdSource: 'X-Amzn-Trace-Id',
    },
})
```
Note this is a breaking change so will have to be included in a major
release of the beeline.