### PR TITLE
Fix access to TRACE_SPAN_ID as it now is part of the Span payload

### DIFF
--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -148,7 +148,7 @@ module.exports = class LibhoneyEventAPI {
       return;
     }
     if (parentContext.stack.length > 0) {
-      parentId = parentContext.stack[parentContext.stack.length - 1][schema.TRACE_SPAN_ID];
+      parentId = parentContext.stack[parentContext.stack.length - 1].payload[schema.TRACE_SPAN_ID];
     }
     if (!parentId) {
       parentId = parentContext.parentId;


### PR DESCRIPTION
This PR updates `startAsyncSpan` to fetch the parent span id from the span payload property.

Fixes #196 