### PR TITLE
add a test for trace fields lining up when using async spans

### DIFF
--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -381,6 +381,37 @@ test("sub-events will get manual tracing fields", () => {
   expect(subSpanData[schema.TRACE_SPAN_NAME]).toBe("name2");
 });
 
+test("async sub-spans will get tracing fields", () => {
+  const honey = api._apiForTesting().honey;
+
+  let rootSpan = api.startTrace({
+    [schema.EVENT_TYPE]: "source",
+    [schema.TRACE_SPAN_NAME]: "name",
+  });
+
+  api.startAsyncSpan(
+    {
+      [schema.EVENT_TYPE]: "source2",
+      [schema.TRACE_SPAN_NAME]: "name2",
+    },
+    subSpan => {
+      // finish it immediately
+      api.finishSpan(subSpan);
+    }
+  );
+  api.finishTrace(rootSpan);
+
+  // libhoney should have been told to send two events
+  expect(honey.transmission.events.length).toBe(2);
+
+  let subSpanData = JSON.parse(honey.transmission.events[0].postData);
+  let rootSpanData = JSON.parse(honey.transmission.events[1].postData);
+
+  expect(subSpanData[schema.TRACE_PARENT_ID]).toBe(rootSpanData[schema.TRACE_SPAN_ID]);
+  expect(subSpanData[schema.TRACE_ID]).toBe(rootSpanData[schema.TRACE_ID]);
+  expect(subSpanData[schema.TRACE_SPAN_NAME]).toBe("name2");
+});
+
 describe("custom context", () => {
   test("it should be added to request events", () => {
     const honey = api._apiForTesting().honey;


### PR DESCRIPTION
Add a test for #197's fix - it's essentially identical to the version for synchronous spans.

Verified that it fails prior to #197, and passes after.