### PR TITLE
[http] make .get/.request work for both 2 (all node versions) and 3 (node 10.9.0+) arg versions

### DIFF
--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -8,36 +8,50 @@ let instrumentHTTP = (http, opts = {}) => {
   shimmer.wrap(http, "get", function(_original) {
     // we have to replace http.get since it references request through
     // a closure (so we can't replace the value it uses..)
-    return function(options, cb) {
-      var req = http.request(options, cb);
+    return function(_url, _options, _cb) {
+      let req = http.request.apply(this, Array.from(arguments));
       req.end();
       return req;
     };
   });
 
   shimmer.wrap(http, "request", function(original) {
-    return function(options, cb) {
+    // node 10+ supports a three arg form.  Instead of writing both implementations,
+    // dynamically switch on arg types.  I _hate_ code that does this, but it's easier
+    // and cleaner than the alternative.
+    return function(_url, options, cb) {
       if (!api.traceActive()) {
-        return original.apply(this, [options, cb]);
+        return original.apply(this, Array.from(arguments));
       }
 
-      // let's make sure we have an object (or a url) for options.
-      if (typeof options === "string") {
-        options = url.parse(options); // node 10 doesn't use url.parse (except as a fallback).  figure out how to handle that?
-      } else {
-        // shallow-clone options since we'll be modifying it below (adding our header)
-        options = Object.assign({}, options);
-      }
+      let combinedOptions = {};
+      let callback;
 
-      // another copy so we can normalize things
-      let formatOptions = Object.assign({}, options);
+      if (typeof _url === "string") {
+        combinedOptions = Object.assign({}, url.parse(_url)); // node 10 doesn't use url.parse (except as a fallback).  figure out how to handle that?
+        delete combinedOptions.href;
+        if (typeof options === "object") {
+          Object.assign(combinedOptions, options);
+          // we need to fix up `host` after this (if it wasn't specified in options), since the port might have changed.
+          if (!options.host) {
+            combinedOptions.host = `${combinedOptions.hostname}:${combinedOptions.port}`;
+          }
+          callback = cb;
+        } else {
+          callback = options;
+        }
+      } else if (typeof _url === "object") {
+        // the two-arg form.
+        combinedOptions = Object.assign({}, _url);
+        callback = options;
+      }
 
       // make sure options is populated enough for url.format to give us reasonable results.  these are all defaults from nodejs docs.
-      formatOptions.protocol = formatOptions.protocol || "http:";
-      formatOptions.port = formatOptions.port !== 80 ? formatOptions.port : null;
-      formatOptions.pathname = formatOptions.path || "/";
-      if (!formatOptions.hostname && !formatOptions.host) {
-        formatOptions.hostname = "localhost";
+      combinedOptions.protocol = combinedOptions.protocol || "http:";
+      combinedOptions.port = combinedOptions.port !== 80 ? combinedOptions.port : null;
+      combinedOptions.pathname = combinedOptions.path || "/";
+      if (!combinedOptions.hostname && !combinedOptions.host) {
+        combinedOptions.hostname = "localhost";
       }
 
       return api.startAsyncSpan(
@@ -45,26 +59,26 @@ let instrumentHTTP = (http, opts = {}) => {
           [schema.EVENT_TYPE]: "http",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
           [schema.TRACE_SPAN_NAME]: options.method || "GET",
-          url: url.format(formatOptions),
+          url: url.format(combinedOptions),
         },
         span => {
           let wrapped_cb = function(res) {
             api.finishSpan(span, "request");
-            if (cb) {
-              return cb.apply(this, [res]);
+            if (callback) {
+              return callback.apply(this, [res]);
             }
           };
 
-          // shallow clone options.headers, adding our tracing headers in
-          options.headers = Object.assign({}, options.headers, {
+          // shallow clone combinedOptions.headers, adding our tracing headers in
+          combinedOptions.headers = Object.assign({}, combinedOptions.headers, {
             [api.TRACE_HTTP_HEADER]: api.marshalTraceContext(api.getTraceContext()),
           });
 
-          if (cb) {
-            return original.apply(this, [options, wrapped_cb]);
+          if (callback) {
+            return original.apply(this, [combinedOptions, wrapped_cb]);
           } else {
             // the user didn't specify a callback, add it as a "response" handler ourselves
-            return original.apply(this, [options]).on("response", wrapped_cb);
+            return original.apply(this, [combinedOptions]).on("response", wrapped_cb);
           }
         }
       );

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -79,6 +79,7 @@ test("url as options", done => {
 test("node 10+ url + options", done => {
   if (semver.lt(process.version, "10.0.0")) {
     // don't run this test for these versions
+    done();
     return;
   }
 

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -1,5 +1,6 @@
 /* eslint-env node, jest */
-const http = require("http"),
+const semver = require("semver"),
+  http = require("http"),
   instrumentHttp = require("./http"),
   schema = require("../schema"),
   tracker = require("../async_tracker"),
@@ -55,6 +56,36 @@ test("url as options", done => {
   tracker.setTracked(newMockContext());
 
   http.get(
+    {
+      hostname: "localhost",
+      port: 9009,
+    },
+    res => {
+      expect(res.headers[api.TRACE_HTTP_HEADER.toLowerCase()]).toBe(
+        "1;trace_id=0,parent_id=51001,context=e30="
+      );
+      expect(api._apiForTesting().sentEvents).toEqual([
+        expect.objectContaining({
+          [schema.EVENT_TYPE]: "http",
+          name: "GET",
+          url: "http://localhost:9009/",
+        }),
+      ]);
+      done();
+    }
+  );
+});
+
+test("node 10+ url + options", done => {
+  if (semver.lt(process.version, "10.0.0")) {
+    // don't run this test for these versions
+    return;
+  }
+
+  tracker.setTracked(newMockContext());
+
+  http.get(
+    "http://localhost:80",
     {
       hostname: "localhost",
       port: 9009,

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -13,13 +13,13 @@ function newMockContext() {
 instrumentHttp(http);
 
 let server;
-beforeAll(() => {
+beforeAll(done => {
   server = http.createServer((req, res) => {
     res.setHeader(api.TRACE_HTTP_HEADER, req.headers[api.TRACE_HTTP_HEADER.toLowerCase()]);
     res.end();
   });
 
-  server.listen(9009, "localhost");
+  server.listen(9009, "localhost", done);
 });
 
 afterAll(() => {

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -79,8 +79,8 @@ test("url as options", done => {
   );
 });
 
-test("node 10+ url + options", done => {
-  if (semver.lt(process.version, "10.0.0")) {
+test("node 10.9.0+ url + options", done => {
+  if (semver.lt(process.version, "10.9.0")) {
     // don't run this test for these versions
     done();
     return;
@@ -110,8 +110,8 @@ test("node 10+ url + options", done => {
   );
 });
 
-test("node 10+ url + options, without active trace", done => {
-  if (semver.lt(process.version, "10.0.0")) {
+test("node 10.9.0+ url + options, without active trace", done => {
+  if (semver.lt(process.version, "10.9.0")) {
     // don't run this test for these versions
     done();
     return;

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -15,7 +15,10 @@ instrumentHttp(http);
 let server;
 beforeAll(done => {
   server = http.createServer((req, res) => {
-    res.setHeader(api.TRACE_HTTP_HEADER, req.headers[api.TRACE_HTTP_HEADER.toLowerCase()]);
+    res.setHeader(
+      api.TRACE_HTTP_HEADER,
+      req.headers[api.TRACE_HTTP_HEADER.toLowerCase()] || "missing"
+    );
     res.end();
   });
 
@@ -102,6 +105,27 @@ test("node 10+ url + options", done => {
           url: "http://localhost:9009/",
         }),
       ]);
+      done();
+    }
+  );
+});
+
+test("node 10+ url + options, without active trace", done => {
+  if (semver.lt(process.version, "10.0.0")) {
+    // don't run this test for these versions
+    done();
+    return;
+  }
+
+  http.get(
+    "http://localhost:80",
+    {
+      hostname: "localhost",
+      port: 9009,
+    },
+    res => {
+      expect(res.headers[api.TRACE_HTTP_HEADER.toLowerCase()]).toBe("missing");
+      expect(api._apiForTesting().sentEvents).toEqual([]);
       done();
     }
   );

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -9,36 +9,50 @@ let instrumentHTTPS = (https, opts = {}) => {
   shimmer.wrap(https, "get", function(_original) {
     // we have to replace http.get since it references request through
     // a closure (so we can't replace the value it uses..)
-    return function(options, cb) {
-      var req = https.request(options, cb);
+    return function(_url, _options, _cb) {
+      let req = https.request.apply(this, Array.from(arguments));
       req.end();
       return req;
     };
   });
 
   shimmer.wrap(https, "request", function(original) {
-    return function(options, cb) {
+    // node 10+ supports a three arg form.  Instead of writing both implementations,
+    // dynamically switch on arg types.  I _hate_ code that does this, but it's easier
+    // and cleaner than the alternative.
+    return function(_url, options, cb) {
       if (!api.traceActive()) {
         return original.apply(this, [options, cb]);
       }
 
-      // let's make sure we have an object (or a url) for options.
-      if (typeof options === "string") {
-        options = url.parse(options); // node 10 doesn't use url.parse (except as a fallback).  figure out how to handle that?
-      } else {
-        // shallow-clone options since we'll be modifying it below (adding our header)
-        options = Object.assign({}, options);
+      let combinedOptions = {};
+      let callback;
+
+      if (typeof _url === "string") {
+        combinedOptions = Object.assign({}, url.parse(_url)); // node 10 doesn't use url.parse (except as a fallback).  figure out how to handle that?
+        delete combinedOptions.href;
+        if (typeof options === "object") {
+          Object.assign(combinedOptions, options);
+          // we need to fix up `host` after this (if it wasn't specified in options), since the port might have changed.
+          if (!options.host) {
+            combinedOptions.host = `${combinedOptions.hostname}:${combinedOptions.port}`;
+          }
+          callback = cb;
+        } else {
+          callback = options;
+        }
+      } else if (typeof _url === "object") {
+        // the two-arg form.
+        combinedOptions = Object.assign({}, _url);
+        callback = options;
       }
 
-      // another copy so we can normalize things
-      let formatOptions = Object.assign({}, options);
-
       // make sure options is populated enough for url.format to give us reasonable results.  these are all defaults from nodejs docs.
-      formatOptions.protocol = formatOptions.protocol || "https:";
-      formatOptions.port = formatOptions.port !== 443 ? formatOptions.port : null;
-      formatOptions.pathname = formatOptions.path || "/";
-      if (!formatOptions.hostname && !formatOptions.host) {
-        formatOptions.hostname = "localhost";
+      combinedOptions.protocol = combinedOptions.protocol || "https:";
+      combinedOptions.port = combinedOptions.port !== 443 ? combinedOptions.port : null;
+      combinedOptions.pathname = combinedOptions.path || "/";
+      if (!combinedOptions.hostname && !combinedOptions.host) {
+        combinedOptions.hostname = "localhost";
       }
 
       return api.startAsyncSpan(
@@ -46,7 +60,7 @@ let instrumentHTTPS = (https, opts = {}) => {
           [schema.EVENT_TYPE]: "https",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
           [schema.TRACE_SPAN_NAME]: options.method || "GET",
-          url: url.format(formatOptions),
+          url: url.format(combinedOptions),
         },
         span => {
           // in node 8.x, https calls into http.  currently we don't have a way
@@ -57,21 +71,21 @@ let instrumentHTTPS = (https, opts = {}) => {
           // callback here.
           let wrapped_cb = tracker.bindFunction(function(res) {
             api.finishSpan(span, "request");
-            if (cb) {
-              return cb.apply(this, [res]);
+            if (callback) {
+              return callback.apply(this, [res]);
             }
           });
 
           // shallow clone options.headers, adding our tracing headers in
-          options.headers = Object.assign({}, options.headers, {
+          combinedOptions.headers = Object.assign({}, combinedOptions.headers, {
             [api.TRACE_HTTP_HEADER]: api.marshalTraceContext(api.getTraceContext()),
           });
 
-          if (cb) {
-            return original.apply(this, [options, wrapped_cb]);
+          if (callback) {
+            return original.apply(this, [combinedOptions, wrapped_cb]);
           } else {
             // the user didn't specify a callback, add it as a "response" handler ourselves
-            return original.apply(this, [options]).on("response", wrapped_cb);
+            return original.apply(this, [combinedOptions]).on("response", wrapped_cb);
           }
         }
       );

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -22,7 +22,7 @@ let instrumentHTTPS = (https, opts = {}) => {
     // and cleaner than the alternative.
     return function(_url, options, cb) {
       if (!api.traceActive()) {
-        return original.apply(this, [options, cb]);
+        return original.apply(this, Array.from(arguments));
       }
 
       let combinedOptions = {};

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -89,8 +89,8 @@ test("url as options", done => {
   );
 });
 
-test("node 10+ url + options", done => {
-  if (semver.lt(process.version, "10.0.0")) {
+test("node 10.9.0+ url + options", done => {
+  if (semver.lt(process.version, "10.9.0")) {
     // don't run this test for these versions
     done();
     return;
@@ -116,8 +116,8 @@ test("node 10+ url + options", done => {
   );
 });
 
-test("node 10+ url + options, without active trace", done => {
-  if (semver.lt(process.version, "10.0.0")) {
+test("node 10.9.0+ url + options, without active trace", done => {
+  if (semver.lt(process.version, "10.9.0")) {
     // don't run this test for these versions
     done();
     return;

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -88,3 +88,30 @@ test("url as options", done => {
     }
   );
 });
+
+test("node 10+ url + options", done => {
+  if (semver.lt(process.version, "10.0.0")) {
+    // don't run this test for these versions
+    done();
+    return;
+  }
+
+  tracker.setTracked(newMockContext());
+
+  https.get(
+    "https://google.com:80",
+    {
+      port: 443,
+    },
+    _res => {
+      expect(api._apiForTesting().sentEvents).toEqual([
+        expect.objectContaining({
+          [schema.EVENT_TYPE]: "https",
+          name: "GET",
+          url: "https://google.com:443/",
+        }),
+      ]);
+      done();
+    }
+  );
+});

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -115,3 +115,22 @@ test("node 10+ url + options", done => {
     }
   );
 });
+
+test("node 10+ url + options, without active trace", done => {
+  if (semver.lt(process.version, "10.0.0")) {
+    // don't run this test for these versions
+    done();
+    return;
+  }
+
+  https.get(
+    "https://google.com:80",
+    {
+      port: 443,
+    },
+    _res => {
+      expect(api._apiForTesting().sentEvents).toEqual([]);
+      done();
+    }
+  );
+});


### PR DESCRIPTION
Node 10.9.0 added a 3 arg form for .get/.request in `http` and `https`, so we now have 2 forms to support:

```
http.request(options[, callback])
http.request(url[, options][, callback])
```

Instead of including a semver check in the instrumentation, handle the 3-arg form everywhere (this may or may not be the right approach, but it's definitely easier to write.)

Fixes #204 