### PR TITLE
Add null guard to addContext mock implementation

### DIFF
--- a/lib/api/mock.js
+++ b/lib/api/mock.js
@@ -83,6 +83,9 @@ module.exports = class MockEventAPI {
 
   addContext(map) {
     let context = tracker.getTracked();
+    if (!context || context.stack.length === 0) {
+      return;
+    }
     Object.assign(context.stack[0], map);
   }
 


### PR DESCRIPTION
This PR brings the `addContext` implementation in `MockEventAPI` into
line with `LibhoneyEventAPI`.

The implementation of `addContext` in `LibhoneyEventAPI` checks that
a context exists before attempt to modify the context's stack.

The `MockEventAPI` implementation does not have this check. This can
cause tests to fail in services where the mock implementation is used
in test environments.