### PR TITLE
Add response context to http/s instrumentation

### DIFF
--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -63,6 +63,13 @@ let instrumentHTTP = (http, opts = {}) => {
         },
         span => {
           let wrapped_cb = function(res) {
+            span.addContext({
+              "response.http_version": res.httpVersion,
+              "response.status_code": res.statusCode,
+              "response.content_length": res.headers["content-length"],
+              "response.content_type": res.headers["content-type"],
+              "response.content_encoding": res.headers["content-encoding"],
+            });
             api.finishSpan(span, "request");
             if (callback) {
               return callback.apply(this, [res]);

--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -19,6 +19,9 @@ beforeAll(done => {
       api.TRACE_HTTP_HEADER,
       req.headers[api.TRACE_HTTP_HEADER.toLowerCase()] || "missing"
     );
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Content-Encoding", "gzip");
+    res.setHeader("Content-Length", "42");
     res.end();
   });
 
@@ -77,6 +80,29 @@ test("url as options", done => {
       done();
     }
   );
+});
+
+test("correct response context", done => {
+  tracker.setTracked(newMockContext());
+
+  http.get("http://localhost:9009", res => {
+    expect(res.headers[api.TRACE_HTTP_HEADER.toLowerCase()]).toBe(
+      "1;trace_id=0,parent_id=51001,context=e30="
+    );
+    expect(api._apiForTesting().sentEvents).toEqual([
+      expect.objectContaining({
+        [schema.EVENT_TYPE]: "http",
+        name: "GET",
+        url: "http://localhost:9009/",
+        "response.http_version": res.httpVersion,
+        "response.status_code": res.statusCode,
+        "response.content_length": res.headers["content-length"],
+        "response.content_type": res.headers["content-type"],
+        "response.content_encoding": res.headers["content-encoding"],
+      }),
+    ]);
+    done();
+  });
 });
 
 test("node 10.9.0+ url + options", done => {

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -70,6 +70,13 @@ let instrumentHTTPS = (https, opts = {}) => {
           // called with the http context active, not ours.  so we have to bind our
           // callback here.
           let wrapped_cb = tracker.bindFunction(function(res) {
+            span.addContext({
+              "response.http_version": res.httpVersion,
+              "response.status_code": res.statusCode,
+              "response.content_length": res.headers["content-length"],
+              "response.content_type": res.headers["content-type"],
+              "response.content_encoding": res.headers["content-encoding"],
+            });
             api.finishSpan(span, "request");
             if (callback) {
               return callback.apply(this, [res]);

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -89,6 +89,26 @@ test("url as options", done => {
   );
 });
 
+test("correct response context", done => {
+  tracker.setTracked(newMockContext());
+
+  https.get("https://example.com/", _res => {
+    expect(api._apiForTesting().sentEvents).toEqual([
+      expect.objectContaining({
+        [schema.EVENT_TYPE]: "https",
+        [schema.TRACE_SPAN_NAME]: "GET",
+        url: "https://example.com/",
+        "response.http_version": _res.httpVersion,
+        "response.status_code": _res.statusCode,
+        "response.content_length": _res.headers["content-length"],
+        "response.content_type": _res.headers["content-type"],
+        "response.content_encoding": _res.headers["content-encoding"],
+      }),
+    ]);
+    done();
+  });
+});
+
 test("node 10.9.0+ url + options", done => {
   if (semver.lt(process.version, "10.9.0")) {
     // don't run this test for these versions


### PR DESCRIPTION
* Validated locally to see context correctly added to http/s spans.

It would be very beneficial to have some context around these outbound calls in order to determine if the call was successful in logging.