### PR TITLE
replace options.method with combinedOptions.method

### DIFF
--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -58,7 +58,7 @@ let instrumentHTTP = (http, opts = {}) => {
         {
           [schema.EVENT_TYPE]: "http",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
-          [schema.TRACE_SPAN_NAME]: options.method || "GET",
+          [schema.TRACE_SPAN_NAME]: combinedOptions.method || "GET",
           url: url.format(combinedOptions),
         },
         span => {

--- a/lib/instrumentation/https.js
+++ b/lib/instrumentation/https.js
@@ -59,7 +59,7 @@ let instrumentHTTPS = (https, opts = {}) => {
         {
           [schema.EVENT_TYPE]: "https",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
-          [schema.TRACE_SPAN_NAME]: options.method || "GET",
+          [schema.TRACE_SPAN_NAME]: combinedOptions.method || "GET",
           url: url.format(combinedOptions),
         },
         span => {


### PR DESCRIPTION
Tiny tweak: this was causing requests to reject if the incoming request used the 2-arg format, since "options" may be undefined in that situation.