### PR TITLE
check for custom context prefix before adding

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -25,7 +25,7 @@ function mapFieldsToApp(map) {
     }
     mapped[schema.customContext(k)] = map[k];
   }
-  console.log(mapped);
+
   return mapped;
 }
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -13,11 +13,19 @@ const { honeycomb, aws } = propagation;
 
 let apiImpl;
 
+// incoming custom trace context fields get prefixed
 function mapFieldsToApp(map) {
   let mapped = {};
+
   for (const k of Object.getOwnPropertyNames(map)) {
+    if (!k.startsWith(schema.CUSTOM_CONTEXT_PREFIX)) {
+      mapped[schema.customContext(k)] = map[k];
+    } else {
+      mapped.k = map[k];
+    }
     mapped[schema.customContext(k)] = map[k];
   }
+  console.log(mapped);
   return mapped;
 }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -16,4 +16,7 @@ exports.TRACE_SPAN_ID = "trace.span_id";
 exports.TRACE_SERVICE_NAME = "service_name";
 exports.TRACE_SPAN_NAME = "name";
 
-exports.customContext = key => `app.${key}`;
+const CUSTOM_CONTEXT_PREFIX = "app.";
+
+exports.CUSTOM_CONTEXT_PREFIX = CUSTOM_CONTEXT_PREFIX;
+exports.customContext = key => `${CUSTOM_CONTEXT_PREFIX}${key}`;


### PR DESCRIPTION
Closes #207 

On prefixing custom context fields with `.app` before adding to the span payload, this adds a check for the prefix to avoid adding it multiple times