### PR TITLE
add tests to confirm one-argument get requests will work

### DIFF
--- a/lib/instrumentation/http.test.js
+++ b/lib/instrumentation/http.test.js
@@ -130,3 +130,9 @@ test("node 10.9.0+ url + options, without active trace", done => {
     }
   );
 });
+
+test("url as a string, 1 argument", done => {
+  tracker.setTracked(newMockContext());
+  const req = http.get("http://localhost:9009");
+  req.on("response", done);
+});

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -134,3 +134,9 @@ test("node 10.9.0+ url + options, without active trace", done => {
     }
   );
 });
+
+test("url as a string, 1 argument", done => {
+  tracker.setTracked(newMockContext());
+  const req = https.get("http://localhost:9009");
+  req.on("response", done);
+});

--- a/lib/instrumentation/https.test.js
+++ b/lib/instrumentation/https.test.js
@@ -137,6 +137,6 @@ test("node 10.9.0+ url + options, without active trace", done => {
 
 test("url as a string, 1 argument", done => {
   tracker.setTracked(newMockContext());
-  const req = https.get("http://localhost:9009");
+  const req = https.get("https://localhost:9009");
   req.on("response", done);
 });


### PR DESCRIPTION
Confirmed this test breaks for the exception I was running into, thanks @toshok!