### PR TITLE
2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-beeline",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "10.21.0"
   },
   "license": "Apache-2.0",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/honeycombio/beeline-nodejs.git"


### PR DESCRIPTION
Notes that will go into the release if this is good to go:

Improvements:
- bump dep to libhoney to ^2.2.1 (#234) @toshok
   (adds console transmission option, enforce response queue limits) 
- common http request headers added to auto-instrumented fields (#206) @paulosman 
- support for 3-arg http/s .get/.request (node-10.0.9) (#213) @toshok
- null guard to addContext mock implementation (#215) @kenmclennan 
- trace ids and span ids conform to w3c spec (#216) @katiebayes 
- response context in http/s (#223) @loganrdavis-ns8 

Some fixes:
- fix use of function for parentIdSource (#205) @mikesimons 
- fix multi-prefixing of .app behavior on custom fields (#226) @katiebayes 
