### PR TITLE
removes external crypto dependency, a node built-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1511,11 +1511,6 @@
         "which": "^1.2.9"
       }
     },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-    },
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@opentelemetry/core": "^0.9.0",
     "array-flatten": "^2.1.2",
-    "crypto": "^1.0.1",
     "debug": "^4.1.1",
     "libhoney": "^2.2.1",
     "on-headers": "^1.0.2",


### PR DESCRIPTION
"npm WARN deprecated crypto@1.0.1: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."