### PR TITLE
add type check on callback for wrapping callback arguments

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -62,7 +62,7 @@ function instrumentMongodb(mongodb, opts = {}) {
               span.addContext(prefixKeys("db", additionalContext(...populatedArgs)));
             }
 
-            if (callback) {
+            if (callback && typeof callback === "function") {
               let wrapped_cb = api.bindFunctionToTrace(function(...cb_args) {
                 api.finishSpan(span, eventName);
                 return callback(...cb_args);


### PR DESCRIPTION
Adds a type check to the "truthy" check for callback before wrapping it. This should avoid breaking when instrumentation tries to shim to a mongodb method that does not have a callback as a final argument.