### PR TITLE
Changelog, circle tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # YAML Anchors to reduce copypasta
 
 # This is necessary for job to run when a tag is created
-filters_all_tags: &filters_all_tags
+filters_always: &filters_always
   filters:
     tags:
       only: /.*/
@@ -19,14 +19,15 @@ matrix_nodeversions: &matrix_nodeversions
     parameters:
       nodeversion: ["9", "10", "11", "12", "14"]
 
-current_nodeversion: &current_nodeversion "12"
+# Default version of node to use for lint and publishing
+default_nodeversion: &default_nodeversion "12"
 
 executors:
   node:
     parameters:
       nodeversion:
         type: string
-        default: *current_nodeversion
+        default: *default_nodeversion
     docker:
       - image: circleci/node:<< parameters.nodeversion >>
         environment:
@@ -67,7 +68,7 @@ jobs:
     parameters:
       nodeversion:
         type: string
-        default: *current_nodeversion
+        default: *default_nodeversion
     executor:
       name: node
     steps:
@@ -80,9 +81,10 @@ jobs:
       name: node
     steps:
       - checkout
+      - run: mkdir -p ~/artifacts
       - run: npm ci
       - run: npm pack
-      - run: cp  honeycomb-beeline-*.tgz ~/artifacts
+      - run: cp ./honeycomb-beeline-*.tgz ~/artifacts/
       - persist_to_workspace:
           root: ~/
           paths:
@@ -125,14 +127,14 @@ workflows:
   build:
     jobs:
       - lint:
-          <<: *filters_publish
+          <<: *filters_always
       - test:
-          <<: *filters_publish
+          <<: *filters_always
           requires:
             - lint
           <<: *matrix_nodeversions
       - build_artifacts:
-          <<: *filters_publish
+          <<: *filters_always
           requires:
             - test
       - publish_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,35 @@ executors:
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
+  github:
+    docker:
+      - image: cibuilds/github:0.13.0
+
+commands:
+  publish_github:
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Artifacts being published"
+          command: |
+            echo "about to publish to tag ${CIRCLE_TAG}"
+            ls -l ~/artifacts/*
+      - run:
+          name: "GHR Draft"
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+
 jobs:
-  test_libhoney:
+  lint:
+    executor:
+      name: node
+      nodeversion: "12"
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm lint
+
+  test:
     parameters:
       nodeversion:
         type: string
@@ -24,20 +51,40 @@ jobs:
       npm_install:
         type: string
         default: "ci"
-      npm_task:
-        type: string
-        default: "test"
     executor:
       name: node
       nodeversion: "<< parameters.nodeversion >>"
     steps:
       - checkout
-      - run: npm << parameters.npm_install >>
-      - run: npm << parameters.npm_task >>
+      - run: npm i
+      - run: npm lint
+      - run: npm test
 
-  publish:
-    docker:
-      - image: circleci/node:12.12.0-buster
+  build_artifacts:
+    executor:
+      name: node
+      nodeversion: "12"
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm pack
+      - run: cp  honeycomb-beeline-*.tgz ~/artifacts
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: ~/artifacts
+
+  publish_github:
+    executor: github
+    steps:
+      - publish_github
+
+  publish_npm:
+    executor:
+      name: node
+      nodeversion: "12"
     steps:
       - checkout
       - run:
@@ -45,6 +92,12 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm ci
       - run: npm publish
+
+# Anchor to reduce repeating filter
+filters_all: &filters_all
+  filters:
+    tags:
+      only: /.*/
 
 workflows:
   nightly:
@@ -56,140 +109,51 @@ workflows:
               only:
                 - main
     jobs:
-      - test_libhoney:
-          name: lint
-          nodeversion: "12"
-          npm_task: "run lint"
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node9
-          nodeversion: "9"
-          npm_install: "i"
+      - lint:
+          <<: *filters_all
+      - test:
+          <<: *filters_all
           requires:
             - lint
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node1000
-          nodeversion: "10.0.0"
-          npm_install: "i"
-          requires:
-            - lint
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node10
-          nodeversion: "10"
-          requires:
-            - lint
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node11
-          nodeversion: "11"
-          requires:
-            - lint
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node12
-          nodeversion: "12"
-          requires:
-            - lint
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
+          matrix:
+            parameters:
+              nodeversion: ["9", "10.0.0", "10", "11", "12"]
+              npm_install: ["ci"] # CI only available on >=10, maybe?
 
-  build-libhoney:
+  build:
     jobs:
-      - test_libhoney:
-          name: lint
-          nodeversion: "12"
-          npm_task: "run lint"
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node9
-          nodeversion: "9"
-          npm_install: "i"
+      - lint
+      - test:
           requires:
             - lint
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node1000
-          nodeversion: "10.0.0"
-          npm_install: "i"
+          matrix:
+            parameters:
+              nodeversion: ["9", "10.0.0", "10", "11", "12"]
+              npm_install: ["ci"] # CI only available on >=10, maybe?
+      - build_artifacts:
           requires:
-            - lint
+            - test
           filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node10
-          nodeversion: "10"
+            tags:
+              only: /v[0-9].*/
+            branches:
+              ignore: /.*/
+
+      - publish_github:
+          context: Honeycomb Secrets
           requires:
-            - lint
+            - build_artifacts
           filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node11
-          nodeversion: "11"
+            tags:
+              only: /v[0-9].*/
+            branches:
+              ignore: /.*/
+      - publish_npm:
+          context: Honeycomb Secrets
           requires:
-            - lint
+            - test
           filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - test_libhoney:
-          name: test_node12
-          nodeversion: "12"
-          requires:
-            - lint
-          filters:
-              branches:
-                only: /.*/
-              tags:
-                only: /.+/
-      - publish:
-          requires:
-            - test_node9
-            - test_node1000
-            - test_node10
-            - test_node11
-            - test_node12
-          filters:
-              branches:
-                ignore: /.*/
-              tags:
-                only: /.+/
+            tags:
+              only: /v[0-9].*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
     steps:
       - checkout
       - run: npm i
-      - run: npm lint
       - run: npm test
 
   build_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,26 @@
 version: 2.1
 
+# Anchors to reduce repeating filter
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /v[0-9].*/
+    branches:
+      ignore: /.*/
+
+matrix_nodeversions: &matrix_nodeversions
+  matrix:
+    parameters:
+      nodeversion: ["9", "10.0.0", "10", "11", "12"]
+
+current_nodeversion: &current_nodeversion "12"
+
 executors:
   node:
     parameters:
       nodeversion:
         type: string
-        default: "12"
+        default: *current_nodeversion
     docker:
       - image: circleci/node:<< parameters.nodeversion >>
         environment:
@@ -37,7 +52,6 @@ jobs:
   lint:
     executor:
       name: node
-      nodeversion: "12"
     steps:
       - checkout
       - run: npm ci
@@ -47,13 +61,9 @@ jobs:
     parameters:
       nodeversion:
         type: string
-        default: "12"
-      npm_install:
-        type: string
-        default: "ci"
+        default: *current_nodeversion
     executor:
       name: node
-      nodeversion: "<< parameters.nodeversion >>"
     steps:
       - checkout
       - run: npm i
@@ -62,7 +72,6 @@ jobs:
   build_artifacts:
     executor:
       name: node
-      nodeversion: "12"
     steps:
       - checkout
       - run: npm ci
@@ -83,7 +92,6 @@ jobs:
   publish_npm:
     executor:
       name: node
-      nodeversion: "12"
     steps:
       - checkout
       - run:
@@ -91,18 +99,6 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm ci
       - run: npm publish
-
-# Anchor to reduce repeating filter
-filters_all: &filters_all
-  filters:
-    tags:
-      only: /.*/
-filters_publish: &filters_publish
-  filters:
-    tags:
-      only: /v[0-9].*/
-    branches:
-      ignore: /.*/
 
 workflows:
   nightly:
@@ -114,16 +110,11 @@ workflows:
               only:
                 - main
     jobs:
-      - lint:
-          <<: *filters_all
+      - lint
       - test:
-          <<: *filters_all
           requires:
             - lint
-          matrix:
-            parameters:
-              nodeversion: ["9", "10.0.0", "10", "11", "12"]
-              npm_install: ["ci"] # CI only available on >=10, maybe?
+          <<: *matrix_nodeversions
 
   build:
     jobs:
@@ -131,10 +122,7 @@ workflows:
       - test:
           requires:
             - lint
-          matrix:
-            parameters:
-              nodeversion: ["9", "10.0.0", "10", "11", "12"]
-              npm_install: ["ci"] # CI only available on >=10, maybe?
+          <<: *matrix_nodeversions
       - build_artifacts:
           <<: *filters_publish
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run: npm lint
+      - run: npm run lint
 
   test:
     parameters:
@@ -98,6 +98,12 @@ filters_all: &filters_all
   filters:
     tags:
       only: /.*/
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /v[0-9].*/
+    branches:
+      ignore: /.*/
 
 workflows:
   nightly:
@@ -131,29 +137,16 @@ workflows:
               nodeversion: ["9", "10.0.0", "10", "11", "12"]
               npm_install: ["ci"] # CI only available on >=10, maybe?
       - build_artifacts:
+          <<: *filters_publish
           requires:
             - test
-          filters:
-            tags:
-              only: /v[0-9].*/
-            branches:
-              ignore: /.*/
-
       - publish_github:
+          <<: *filters_publish
           context: Honeycomb Secrets
           requires:
             - build_artifacts
-          filters:
-            tags:
-              only: /v[0-9].*/
-            branches:
-              ignore: /.*/
       - publish_npm:
+          <<: *filters_publish
           context: Honeycomb Secrets
           requires:
             - test
-          filters:
-            tags:
-              only: /v[0-9].*/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ filters_publish: &filters_publish
   filters:
     tags:
       only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
 
 matrix_nodeversions: &matrix_nodeversions
   matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,23 @@
 version: 2.1
 
-# Anchors to reduce repeating filter
+# YAML Anchors to reduce copypasta
+
+# This is necessary for job to run when a tag is created
+filters_all_tags: &filters_all_tags
+  filters:
+    tags:
+      only: /.*/
+
+# Restrict running to only be on tags starting with vNNNN
 filters_publish: &filters_publish
   filters:
     tags:
-      only: /v[0-9].*/
-    branches:
-      ignore: /.*/
+      only: /^v[0-9].*/
 
 matrix_nodeversions: &matrix_nodeversions
   matrix:
     parameters:
-      nodeversion: ["9", "10.0.0", "10", "11", "12"]
+      nodeversion: ["9", "10", "11", "12", "14"]
 
 current_nodeversion: &current_nodeversion "12"
 
@@ -118,8 +124,10 @@ workflows:
 
   build:
     jobs:
-      - lint
+      - lint:
+          <<: *filters_publish
       - test:
+          <<: *filters_publish
           requires:
             - lint
           <<: *matrix_nodeversions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# beeline-nodejs changelog
+
+## 2.3.1
+
+### Misc
+
+- Added CHANGELOG.md
+- Updates to CI configuration and documentation
+- Updated version management.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ open issues or a pull request with your change. Remember to add your name to the
 CONTRIBUTORS file!
 
 All contributions will be released under the Apache License 2.0.
+
+## Releasing new versions
+
+Use `npm version --no-git-tag-version` to update the version number using `major`, `minor`, `patch`, or the prerelease variants `premajor`, `preminor`, or `prepatch`. We use `--no-git-tag-version` to avoid automatically tagging - tagging with the version automatically triggers a CI run that publishes, and we only want to do that upon merging the PR into `main`.
+
+After doing this, follow our usual instructions for the actual process of tagging and releasing the package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-beeline",
-  "version": "2.3.1-1",
+  "version": "2.3.1-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-beeline",
-  "version": "2.3.1-0",
+  "version": "2.3.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-beeline",
-  "version": "2.3.0",
+  "version": "2.3.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "10.21.0"
   },
   "license": "Apache-2.0",
-  "version": "2.3.1-1",
+  "version": "2.3.1-2",
   "repository": {
     "type": "git",
     "url": "https://github.com/honeycombio/beeline-nodejs.git"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "10.21.0"
   },
   "license": "Apache-2.0",
-  "version": "2.3.1-0",
+  "version": "2.3.1-1",
   "repository": {
     "type": "git",
     "url": "https://github.com/honeycombio/beeline-nodejs.git"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "10.21.0"
   },
   "license": "Apache-2.0",
-  "version": "2.3.0",
+  "version": "2.3.1-0",
   "repository": {
     "type": "git",
     "url": "https://github.com/honeycombio/beeline-nodejs.git"


### PR DESCRIPTION
* Updates to the CircleCI build process so that it more closely matches our "state of the art" process, including:
   * Matrix for node versions
   * Publish to github releases in addition to npm.
   * General cleanup
* Added `CHANGELOG.md`
* Instructions for using `npm version` to update the build number.
* Removed node 10.0.0 from our build matrix - not sure why we had that specific version.
* Added node 14 to our build matrix.

(Note: The build yellow because I changed the name of the CircleCI check from `build-libhoney` to `build`, I will change this in the github configuration as soon as the PR is signed off.)