### PR TITLE
Add prebuilt interop propagation hooks

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -67,18 +67,24 @@ module.exports = {
     TRACE_HTTP_HEADER: honeycomb.TRACE_HTTP_HEADER,
     unmarshalTraceContext: honeycomb.unmarshalTraceContext,
     marshalTraceContext: honeycomb.marshalTraceContext,
+    httpTraceParserHook: honeycomb.httpTraceParserHook,
+    httpTracePropagationHook: honeycomb.httpTracePropagationHook,
   },
 
   aws: {
     TRACE_HTTP_HEADER: aws.TRACE_HTTP_HEADER,
     unmarshalTraceContext: aws.unmarshalTraceContext,
     marshalTraceContext: aws.marshalTraceContext,
+    httpTraceParserHook: aws.httpTraceParserHook,
+    httpTracePropagationHook: aws.httpTracePropagationHook,
   },
 
   w3c: {
     TRACE_HTTP_HEADER: w3c.TRACE_HTTP_HEADER,
     unmarshalTraceContext: w3c.unmarshalTraceContext,
     marshalTraceContext: w3c.marshalTraceContext,
+    httpTraceParserHook: w3c.httpTraceParserHook,
+    httpTracePropagationHook: w3c.httpTracePropagationHook,
   },
 
   startTrace(fields, withTraceId, withParentSpanId, withDataset, propagatedContext = {}) {

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -33,20 +33,22 @@ function unmarshalTraceContext(header) {
 
   const split = header.split(";");
   for (const s of split) {
-    const [nameUnaltered, value] = s.split("=");
-    const name = nameUnaltered.toLowerCase();
-
-    if (name === "root") {
-      traceId = value;
-    } else if (name === "parent") {
-      parentSpanId = value;
-    } else if (name === "self") {
-      self = value;
-    } else {
-      customContext = Object.assign({}, customContext, {
+    const [name, value] = s.split("=");
+    switch (name.toLowerCase()) {
+      case "root":
+        traceId = value;
+        break;
+      case "parent":
+        parentSpanId = value;
+        break;
+      case "self":
+        self = value;
+        break;
+      default:
         // propagate trace headers without case changes
-        [nameUnaltered]: value,
-      });
+        customContext = Object.assign({}, customContext, {
+          [name]: value,
+        });
     }
   }
 

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -31,6 +31,12 @@ function unmarshalTraceContext(header) {
       traceId = value;
     } else if (name === "Parent") {
       parentSpanId = value;
+    } else if (name === "Self") {
+      // use Self as parentSpanId if parentSpanId is undefined
+      // Parent will overwrite this value regardless of order
+      if (!parentSpanId) {
+        parentSpanId = value;
+      }
     } else {
       customContext = Object.assign({}, customContext, {
         [name]: value,

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -15,7 +15,7 @@ function marshalTraceContextv1(context) {
   let spanId = context.parentSpanId || util.currentSpanId(context);
   let traceFields = context.customContext || context.traceContext || {};
 
-  return `Root=${traceId};Parent=${spanId}${util.objToString(traceFields, ";")}`;
+  return `Root=${traceId};Parent=${spanId};${util.objToString(traceFields, ";")}`;
 }
 
 // unmarshalTraceContext takes a string trace header and returns a context

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -79,8 +79,6 @@ function unmarshalTraceContext(header) {
 
 exports.httpTraceParserHook = httpTraceParserHook;
 
-// parserHook functions do not require users to pass an input
-// the instrumentation will provide the request object
 function httpTraceParserHook(httpReq) {
   const header = httpReq.headers["x-amzn-trace-id"];
   if (!header) {

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -18,7 +18,7 @@ function marshalTraceContextv1(context) {
   let contextToSend;
 
   if (Object.keys(traceFields).length > 0) {
-    contextToSend = `;${util.objToString(traceFields, ";")}`;
+    contextToSend = util.objToString(traceFields, ";", "=", ";");
   }
 
   return `Root=${traceId};Parent=${spanId}${contextToSend}`;
@@ -86,5 +86,5 @@ function httpTraceParserHook(req = {}) {
 exports.httpTracePropagationHook = httpTracePropagationHook;
 
 function httpTracePropagationHook(context = {}) {
-  return { [TRACE_HTTP_HEADER]: exports.marshalTraceContext(context) };
+  return { [TRACE_HTTP_HEADER]: marshalTraceContextv1(context) };
 }

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -15,7 +15,11 @@ function marshalTraceContextv1(context) {
   let spanId = context.parentSpanId || util.currentSpanId(context);
   let traceFields = context.customContext || context.traceContext || {};
 
-  let contextToSend;
+  if (!traceId || !spanId) {
+    return null;
+  }
+
+  let contextToSend = "";
 
   if (Object.keys(traceFields).length > 0) {
     contextToSend = util.objToString(traceFields, ";", "=", ";");
@@ -77,14 +81,20 @@ exports.httpTraceParserHook = httpTraceParserHook;
 
 // parserHook functions do not require users to pass an input
 // the instrumentation will provide the request object
-function httpTraceParserHook(req = {}) {
-  const header = req.headers && req.headers["x-amzn-trace-id"];
-
+function httpTraceParserHook(httpReq) {
+  const header = httpReq.headers["x-amzn-trace-id"];
+  if (!header) {
+    return null;
+  }
   return unmarshalTraceContext(header);
 }
 
 exports.httpTracePropagationHook = httpTracePropagationHook;
 
-function httpTracePropagationHook(context = {}) {
-  return { [TRACE_HTTP_HEADER]: marshalTraceContextv1(context) };
+function httpTracePropagationHook(context) {
+  const headerValue = marshalTraceContextv1(context);
+  if (!headerValue) {
+    return null;
+  }
+  return { [TRACE_HTTP_HEADER]: headerValue };
 }

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -22,7 +22,7 @@ function marshalTraceContextv1(context) {
     contextToSend = ";" + elements.join(";");
   }
 
-  return `Root=1-${traceId};Parent=${spanId}${contextToSend}`;
+  return `Root=${traceId};Parent=${spanId}${contextToSend}`;
 }
 
 // unmarshalTraceContext takes a string trace header and returns a context

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -23,23 +23,23 @@ exports.unmarshalTraceContext = unmarshalTraceContext;
 
 function unmarshalTraceContext(header) {
   let traceId, parentSpanId, customContext;
+  let self;
 
   const split = header.split(";");
   for (const s of split) {
-    const [name, value] = s.split("=");
-    if (name === "Root") {
+    const [nameUnaltered, value] = s.split("=");
+    const name = nameUnaltered.toLowerCase();
+
+    if (name === "root") {
       traceId = value;
-    } else if (name === "Parent") {
+    } else if (name === "parent") {
       parentSpanId = value;
-    } else if (name === "Self") {
-      // use Self as parentSpanId if parentSpanId is undefined
-      // Parent will overwrite this value regardless of order
-      if (!parentSpanId) {
-        parentSpanId = value;
-      }
+    } else if (name === "self") {
+      self = value;
     } else {
       customContext = Object.assign({}, customContext, {
-        [name]: value,
+        // propagate trace headers without case changes
+        [nameUnaltered]: value,
       });
     }
   }
@@ -47,6 +47,11 @@ function unmarshalTraceContext(header) {
   if (!traceId) {
     // if we didn't even get a 'Root=' clause, bail.
     return;
+  }
+
+  // use self if parent was not present
+  if (!parentSpanId && self) {
+    parentSpanId = self;
   }
 
   if (!parentSpanId) {

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -60,3 +60,19 @@ function unmarshalTraceContext(header) {
     customContext,
   };
 }
+
+exports.httpTraceParserHook = httpTraceParserHook;
+
+// parserHook functions do not require users to pass an input
+// the instrumentation will provide the request object
+function httpTraceParserHook(req = {}) {
+  const header = req.headers && req.headers["x-amzn-trace-id"];
+
+  return unmarshalTraceContext(header);
+}
+
+exports.httpTracePropagationHook = httpTracePropagationHook;
+
+function httpTracePropagationHook(context = {}) {
+  return { [TRACE_HTTP_HEADER]: exports.marshalTraceContext(context) };
+}

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -15,7 +15,13 @@ function marshalTraceContextv1(context) {
   let spanId = context.parentSpanId || util.currentSpanId(context);
   let traceFields = context.customContext || context.traceContext || {};
 
-  return `Root=${traceId};Parent=${spanId};${util.objToString(traceFields, ";")}`;
+  let contextToSend;
+
+  if (Object.keys(traceFields).length > 0) {
+    contextToSend = `;${util.objToString(traceFields, ";")}`;
+  }
+
+  return `Root=${traceId};Parent=${spanId}${contextToSend}`;
 }
 
 // unmarshalTraceContext takes a string trace header and returns a context

--- a/lib/propagation/aws.js
+++ b/lib/propagation/aws.js
@@ -13,16 +13,9 @@ function marshalTraceContextv1(context) {
   // fall back to execution context structure for backwards compatibility
   let traceId = context.traceId || context.id;
   let spanId = context.parentSpanId || util.currentSpanId(context);
-  let contextToSend = context.customContext || context.traceContext || {};
+  let traceFields = context.customContext || context.traceContext || {};
 
-  if (context.traceContext) {
-    const elements = Object.keys(context.traceContext).map(key => {
-      return `${key}=${context.traceContext[key]}`;
-    });
-    contextToSend = ";" + elements.join(";");
-  }
-
-  return `Root=${traceId};Parent=${spanId}${contextToSend}`;
+  return `Root=${traceId};Parent=${spanId}${util.objToString(traceFields, ";")}`;
 }
 
 // unmarshalTraceContext takes a string trace header and returns a context

--- a/lib/propagation/aws.test.js
+++ b/lib/propagation/aws.test.js
@@ -1,0 +1,176 @@
+/* global require describe test expect */
+const propagation = require("."),
+  schema = require("../schema"),
+  Span = require("../api/span"),
+  cases = require("jest-in-case");
+
+const { aws } = propagation;
+
+// this context structure is the same as what the libhoney event api implementation generate.
+let testContext = {
+  id: "abcdef123456",
+  dataset: "testDataset",
+  stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
+  traceContext: {
+    userID: 1,
+    errorMsg: "failed to sign on",
+    toRetry: true,
+  },
+};
+
+cases(
+  "marshaling aws",
+  opts => expect(aws.marshalTraceContext(opts.testContext)).toEqual(opts.header),
+  [
+    {
+      name: "propagate span as Parent",
+      testContext: {
+        id: "abcdef123456",
+        dataset: "testDataset",
+        stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
+        traceContext: {
+          userID: 1,
+          errorMsg: "failed to sign on",
+          toRetry: true,
+        },
+      },
+      header:
+        "Root=abcdef123456;Parent=0102030405;userID=1;errorMsg=failed to sign on;toRetry=true",
+    },
+    {
+      name: "no trace id",
+      testContext: {
+        id: "",
+        dataset: "testDataset",
+        stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
+        traceContext: {
+          userID: 1,
+          errorMsg: "failed to sign on",
+          toRetry: true,
+        },
+      },
+      header: "Root=;Parent=0102030405;userID=1;errorMsg=failed to sign on;toRetry=true",
+    },
+  ]
+);
+
+cases(
+  "unmarshaling aws",
+  opts => expect(aws.unmarshalTraceContext(opts.contextStr)).toEqual(opts.value),
+  [
+    {
+      name: "aws header with trace context",
+      contextStr:
+        "Root=1-abcdef123456;Self=1-0102030405;userID=1;errorMsg=failed to sign on;toRetry=true",
+      value: {
+        traceId: "1-abcdef123456",
+        parentSpanId: "1-0102030405",
+        customContext: {
+          userID: "1",
+          errorMsg: "failed to sign on",
+          toRetry: "true",
+        },
+      },
+    },
+    {
+      name: "lowercase keys work, custom keys remain unchanged",
+      contextStr:
+        "root=abcdef123456;self=0102030405;userID=1;errorMsg=failed to sign on;toRetry=true",
+      value: {
+        traceId: "abcdef123456",
+        parentSpanId: "0102030405",
+        customContext: {
+          userID: "1",
+          errorMsg: "failed to sign on",
+          toRetry: "true",
+        },
+      },
+    },
+    {
+      name: "aws header with no trace context",
+      contextStr: "Root=abcdef123456;Self=0102030405",
+      value: {
+        traceId: "abcdef123456",
+        parentSpanId: "0102030405",
+      },
+    },
+    {
+      name: "aws header with both self and parent, use self as parentSpanId",
+      contextStr: "Root=abcdef123456;Parent=37501823472;Self=0102030405",
+      value: {
+        traceId: "abcdef123456",
+        parentSpanId: "0102030405",
+      },
+    },
+    {
+      name: "root / parent / no self",
+      contextStr: "Root=abcdef123456;Parent=37501823472",
+      value: {
+        traceId: "abcdef123456",
+        parentSpanId: "37501823472",
+      },
+    },
+    {
+      name: "root / parent / self, use parent as parentSpanId",
+      contextStr: "Root=abcdef123456;Parent=37501823472;Self=0102030405",
+      value: {
+        traceId: "abcdef123456",
+        parentSpanId: "0102030405",
+      },
+    },
+    {
+      name: "aws header missing root",
+      contextStr: "Root=;Self=0102030405",
+      value: undefined,
+    },
+    {
+      name: "aws header with no parent span id, no trace context",
+      contextStr: "Root=abcdef123456",
+      value: {
+        traceId: "abcdef123456",
+        parentSpanId: "abcdef123456",
+      },
+    },
+    {
+      name: "aws header with no parent span id, with trace context",
+      contextStr: "Root=1-abcdef123456;userID=1;errorMsg=failed to sign on;toRetry=true",
+      value: {
+        traceId: "1-abcdef123456",
+        parentSpanId: "1-abcdef123456",
+        customContext: {
+          userID: "1",
+          errorMsg: "failed to sign on",
+          toRetry: "true",
+        },
+      },
+    },
+    {
+      name: "aws header with empty string parent",
+      contextStr: "Root=1-abcdef123456;Parent=",
+      value: {
+        traceId: "1-abcdef123456",
+        parentSpanId: "1-abcdef123456",
+      },
+    },
+    {
+      name: "aws header with empty string root",
+      contextStr: "Root=;Self=0102030405",
+      value: undefined,
+    },
+  ]
+);
+
+describe("roundtrip", () => {
+  test("works", () => {
+    let contextStr = aws.marshalTraceContext(testContext);
+    expect(aws.unmarshalTraceContext(contextStr)).toEqual({
+      traceId: "abcdef123456",
+      parentSpanId: "0102030405",
+      customContext: {
+        userID: "1",
+        errorMsg: "failed to sign on",
+        toRetry: "true",
+      },
+    });
+  });
+});

--- a/lib/propagation/aws.test.js
+++ b/lib/propagation/aws.test.js
@@ -95,11 +95,11 @@ cases(
       },
     },
     {
-      name: "aws header with both self and parent, use self as parentSpanId",
+      name: "aws header with both self and parent, use parent as parentSpanId",
       contextStr: "Root=abcdef123456;Parent=37501823472;Self=0102030405",
       value: {
         traceId: "abcdef123456",
-        parentSpanId: "0102030405",
+        parentSpanId: "37501823472",
       },
     },
     {

--- a/lib/propagation/aws.test.js
+++ b/lib/propagation/aws.test.js
@@ -49,7 +49,7 @@ cases(
           toRetry: true,
         },
       },
-      header: "Root=;Parent=0102030405;userID=1;errorMsg=failed to sign on;toRetry=true",
+      header: null,
     },
   ]
 );

--- a/lib/propagation/aws.test.js
+++ b/lib/propagation/aws.test.js
@@ -95,14 +95,6 @@ cases(
       },
     },
     {
-      name: "aws header with both self and parent, use parent as parentSpanId",
-      contextStr: "Root=abcdef123456;Parent=37501823472;Self=0102030405",
-      value: {
-        traceId: "abcdef123456",
-        parentSpanId: "37501823472",
-      },
-    },
-    {
       name: "root / parent / no self",
       contextStr: "Root=abcdef123456;Parent=37501823472",
       value: {
@@ -115,7 +107,7 @@ cases(
       contextStr: "Root=abcdef123456;Parent=37501823472;Self=0102030405",
       value: {
         traceId: "abcdef123456",
-        parentSpanId: "0102030405",
+        parentSpanId: "37501823472",
       },
     },
     {

--- a/lib/propagation/honeycomb.js
+++ b/lib/propagation/honeycomb.js
@@ -126,3 +126,34 @@ function unmarshalTraceContextv1(payload) {
     dataset,
   };
 }
+
+exports.httpTraceParserHook = httpTraceParserHook;
+
+// parserHook functions do not require users to pass an input
+// the instrumentation will provide the request object
+function httpTraceParserHook(req = {}) {
+  if (!req.headers) {
+    return;
+  }
+  const traceHeaderValue = req.headers[TRACE_HTTP_HEADER.toLowerCase()] || "";
+
+  return unmarshalTraceContext(traceHeaderValue);
+}
+
+exports.httpTracePropagationHook = httpTracePropagationHook;
+
+function httpTracePropagationHook(context = {}) {
+  // tracestate default to undefined so it will only be included when needed
+  let headers = {
+    [TRACE_HTTP_HEADER]: marshalTraceContextv1(context),
+  };
+
+  // add tracestate if there are fields in traceContext
+  const { customContext } = context;
+
+  if (customContext.tracestate) {
+    headers.tracestate = customContext.tracestate;
+  }
+
+  return headers;
+}

--- a/lib/propagation/honeycomb.js
+++ b/lib/propagation/honeycomb.js
@@ -129,14 +129,11 @@ function unmarshalTraceContextv1(payload) {
 
 exports.httpTraceParserHook = httpTraceParserHook;
 
-// parserHook functions do not require users to pass an input
-// the instrumentation will provide the request object
-function httpTraceParserHook(req = {}) {
-  if (!req.headers) {
-    return;
+function httpTraceParserHook(httpReq) {
+  const traceHeaderValue = httpReq.headers[TRACE_HTTP_HEADER.toLowerCase()];
+  if (!traceHeaderValue) {
+    return null;
   }
-  const traceHeaderValue = req.headers[TRACE_HTTP_HEADER.toLowerCase()] || "";
-
   return unmarshalTraceContext(traceHeaderValue);
 }
 

--- a/lib/propagation/honeycomb.test.js
+++ b/lib/propagation/honeycomb.test.js
@@ -1,0 +1,96 @@
+/* global require describe test expect */
+const propagation = require("."),
+  schema = require("../schema"),
+  Span = require("../api/span"),
+  cases = require("jest-in-case");
+
+const { honeycomb } = propagation;
+// this context structure is the same as what the libhoney event api implementation generate.
+let testContext = {
+  id: "abcdef123456",
+  dataset: "testDataset",
+  stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
+  traceContext: {
+    userID: 1,
+    errorMsg: "failed to sign on",
+    toRetry: true,
+  },
+};
+
+describe("marshaling", () => {
+  test("version string prefix", () => {
+    expect(
+      honeycomb.marshalTraceContext(testContext).startsWith(`${honeycomb.VERSION};`)
+    ).toBeTruthy();
+  });
+});
+
+cases(
+  "unmarshaling",
+  opts => expect(honeycomb.unmarshalTraceContext(opts.contextStr)).toEqual(opts.value),
+  [
+    {
+      name: "unsupported version",
+      contextStr: "9999999;.....",
+      value: undefined,
+    },
+    {
+      name: "v1 trace_id + parent_id, missing context",
+      contextStr: "1;trace_id=abcdef,parent_id=12345",
+      value: {
+        traceId: "abcdef",
+        parentSpanId: "12345",
+      },
+    },
+    {
+      name: "v1, missing trace_id",
+      contextStr: "1;parent_id=12345",
+      value: undefined,
+    },
+    {
+      name: "v1, missing parent_id",
+      contextStr: "1;trace_id=12345",
+      value: undefined,
+    },
+    {
+      name: "v1, garbled context",
+      contextStr: "1;trace_id=abcdef,parent_id=12345,context=123~!@@&^@",
+      value: undefined,
+    },
+    {
+      name: "v1, unknown key (otherwise valid)",
+      contextStr: "1;trace_id=abcdef,parent_id=12345,something=unsupported",
+      value: {
+        traceId: "abcdef",
+        parentSpanId: "12345",
+      },
+    },
+    {
+      name: "v1, with context",
+      contextStr: "1;trace_id=abcdef,parent_id=12345,context=eyJmb28iOiJiYXIifQo=",
+      value: {
+        traceId: "abcdef",
+        parentSpanId: "12345",
+        customContext: {
+          foo: "bar",
+        },
+      },
+    },
+  ]
+);
+
+describe("roundtrip", () => {
+  test("works", () => {
+    let contextStr = honeycomb.marshalTraceContext(testContext);
+    expect(honeycomb.unmarshalTraceContext(contextStr)).toEqual({
+      traceId: "abcdef123456",
+      parentSpanId: "0102030405",
+      dataset: "testDataset",
+      customContext: {
+        userID: 1,
+        errorMsg: "failed to sign on",
+        toRetry: true,
+      },
+    });
+  });
+});

--- a/lib/propagation/propagation.test.js
+++ b/lib/propagation/propagation.test.js
@@ -28,7 +28,7 @@ describe("marshaling", () => {
 describe("marshaling aws", () => {
   test("version string prefix", () => {
     expect(aws.marshalTraceContext(testContext)).toEqual(
-      "Root=1-abcdef123456;Parent=0102030405;userID=1;errorMsg=failed to sign on;toRetry=true"
+      "Root=abcdef123456;Parent=0102030405;userID=1;errorMsg=failed to sign on;toRetry=true"
     );
   });
 });

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -45,13 +45,13 @@ function objToString(obj, joinChar = ",", keyChar = "=") {
 exports.stringToObj = stringToObj;
 
 // pass this util a string, return as JSON obj with keys and values
-function stringToObj(string, joinChar = ";", keyChar = "=") {
+function stringToObj(string, joinChar = ",", keyChar = "=") {
   let obj;
   const fields = string.split(joinChar);
 
   fields.map(field => {
     const [name, value] = field.split(keyChar);
-    Object.assign({}, obj, {
+    obj = Object.assign({}, obj, {
       [name]: value,
     });
   });

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -30,7 +30,7 @@ exports.objToString = objToString;
 // joinChar separates fields from each other, keyChar separates keys from values
 function objToString(obj, joinChar = ",", keyChar = "=") {
   let string = "";
-  const keys = Object.keys(obj) || [];
+  const keys = Object.keys(obj);
 
   if (keys.length > 0) {
     const fields = keys.map(key => {

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -28,10 +28,10 @@ exports.objToString = objToString;
 
 // pass this util an object, return as string formatted to go into a trace header
 // joinChar separates fields from each other, keyChar separates keys from values
-function objToString(obj, joinChar = ",", keyChar = "=") {
+function objToString(obj, joinChar = ",", keyChar = "=", prefix = "") {
   const keys = Object.keys(obj);
   const fields = keys.map(key => {
-    return key + keyChar + obj[key];
+    return prefix + key + keyChar + obj[key];
   });
   return fields.join(joinChar);
 }

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -23,3 +23,38 @@ function getPropagationContext(context = {}) {
     customContext: context.traceContext,
   };
 }
+
+exports.objToString = objToString;
+
+// pass this util an object, return as string formatted to go into a trace header
+// joinChar separates fields from each other, keyChar separates keys from values
+// function is written to place a joinChar at the beginning of the string
+function objToString(obj, joinChar = ",", keyChar = "=") {
+  let string = "";
+  const keys = Object.keys(obj);
+
+  if (keys.length > 0) {
+    keys.map(key => {
+      string = string.concat(joinChar, key + keyChar + obj[key]);
+    });
+  }
+
+  return string;
+}
+
+exports.stringToObj = stringToObj;
+
+// pass this util a string, return as JSON obj with keys and values
+function stringToObj(string, joinChar = ";", keyChar = "=") {
+  let obj;
+  const fields = string.split(joinChar);
+
+  fields.map(field => {
+    const [name, value] = field.split(keyChar);
+    Object.assign({}, obj, {
+      [name]: value,
+    });
+  });
+
+  return obj;
+}

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -28,7 +28,6 @@ exports.objToString = objToString;
 
 // pass this util an object, return as string formatted to go into a trace header
 // joinChar separates fields from each other, keyChar separates keys from values
-// function is written to place a joinChar at the beginning of the string
 function objToString(obj, joinChar = ",", keyChar = "=") {
   let string = "";
   const keys = Object.keys(obj) || [];

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -29,17 +29,11 @@ exports.objToString = objToString;
 // pass this util an object, return as string formatted to go into a trace header
 // joinChar separates fields from each other, keyChar separates keys from values
 function objToString(obj, joinChar = ",", keyChar = "=") {
-  let string = "";
   const keys = Object.keys(obj);
-
-  if (keys.length > 0) {
-    const fields = keys.map(key => {
-      return key + keyChar + obj[key];
-    });
-    string = fields.join(joinChar);
-  }
-
-  return string;
+  const fields = keys.map(key => {
+    return key + keyChar + obj[key];
+  });
+  return fields.join(joinChar);
 }
 
 exports.stringToObj = stringToObj;

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -31,7 +31,7 @@ exports.objToString = objToString;
 // function is written to place a joinChar at the beginning of the string
 function objToString(obj, joinChar = ",", keyChar = "=") {
   let string = "";
-  const keys = Object.keys(obj) || {};
+  const keys = Object.keys(obj) || [];
 
   if (keys.length > 0) {
     const fields = keys.map(key => {

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -49,7 +49,7 @@ function stringToObj(string, joinChar = ",", keyChar = "=") {
   let obj;
   const fields = string.split(joinChar);
 
-  fields.map(field => {
+  fields.forEach(field => {
     const [name, value] = field.split(keyChar);
     obj = Object.assign({}, obj, {
       [name]: value,

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -31,9 +31,9 @@ exports.objToString = objToString;
 function objToString(obj, joinChar = ",", keyChar = "=", prefix = "") {
   const keys = Object.keys(obj);
   const fields = keys.map(key => {
-    return prefix + key + keyChar + obj[key];
+    return key + keyChar + obj[key];
   });
-  return fields.join(joinChar);
+  return prefix + fields.join(joinChar);
 }
 
 exports.stringToObj = stringToObj;

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -31,12 +31,13 @@ exports.objToString = objToString;
 // function is written to place a joinChar at the beginning of the string
 function objToString(obj, joinChar = ",", keyChar = "=") {
   let string = "";
-  const keys = Object.keys(obj);
+  const keys = Object.keys(obj) || {};
 
   if (keys.length > 0) {
-    keys.map(key => {
-      string = string.concat(joinChar, key + keyChar + obj[key]);
+    const fields = keys.map(key => {
+      return key + keyChar + obj[key];
     });
+    string = fields.join(joinChar);
   }
 
   return string;

--- a/lib/propagation/util.js
+++ b/lib/propagation/util.js
@@ -30,6 +30,9 @@ exports.objToString = objToString;
 // joinChar separates fields from each other, keyChar separates keys from values
 function objToString(obj, joinChar = ",", keyChar = "=", prefix = "") {
   const keys = Object.keys(obj);
+  if (keys.length == 0) {
+    return "";
+  }
   const fields = keys.map(key => {
     return key + keyChar + obj[key];
   });

--- a/lib/propagation/w3c.js
+++ b/lib/propagation/w3c.js
@@ -1,12 +1,17 @@
 /* global require, exports, __dirname */
+// requiring the OTEL trace header key from the api
+// as well as the parser
 const { TRACE_PARENT_HEADER, parseTraceParent } = require("@opentelemetry/core"),
   path = require("path"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
   debug = require("debug")(`${pkg.name}:propagation:w3c`),
   util = require("./util");
-// requiring the OTEL trace header key from the api
-// as well as the parser
+
 exports.TRACE_HTTP_HEADER = TRACE_PARENT_HEADER;
+const TRACE_HTTP_HEADER = TRACE_PARENT_HEADER;
+
+const TRACE_STATE_HEADER = "tracestate";
+exports.TRACE_STATE_HEADER = TRACE_STATE_HEADER;
 
 const TRACE_ID_REGEX = /^[A-Fa-f0-9]{32}$/g;
 const SPAN_ID_REGEX = /^[A-Fa-f0-9]{16}$/g;
@@ -24,16 +29,16 @@ exports.unmarshalTraceContext = unmarshalTraceContextv1;
 // traceState (optional)     -->  context.traceState (nested field in context: {})
 
 // v1 here refers to honeycomb, the context structure
-function unmarshalTraceContextv1(header) {
+function unmarshalTraceContextv1(traceparent, tracestate) {
   // pull out required fields, ... for all optional
   // using spread operator defaults all values to undefined for invalid header values
 
   try {
-    const parsed = parseTraceParent(header);
-    if (!parsed) {
+    const parsedTraceState = parseTraceParent(traceparent);
+    if (!parsedTraceState) {
       return;
     }
-    const { traceId, spanId } = parsed;
+    const { traceId, spanId } = parsedTraceState;
     return {
       traceId,
       parentSpanId: spanId,
@@ -76,4 +81,36 @@ function marshalTraceContextv1(context) {
   // currently we do not propagate traceFlags
   // we will revisit as opentelemetry sampling evolves
   return `00-${traceId}-${parentSpanId}-01`;
+}
+
+exports.httpTraceParserHook = httpTraceParserHook;
+
+// parserHook functions do not require users to pass an input
+// the instrumentation will provide the request object
+function httpTraceParserHook(req = {}) {
+  const { traceparent, tracestate } = req.headers;
+
+  return exports.unmarshalTraceContext({
+    traceparent,
+    tracestate,
+  });
+}
+
+exports.httpTracePropagationHook = httpTracePropagationHook;
+
+function httpTracePropagationHook(context = {}) {
+  console.log(context);
+  // tracestate default to undefined so it will only be included when needed
+  let headers = {
+    [TRACE_HTTP_HEADER]: marshalTraceContext(context),
+  };
+
+  // add tracestate if there are fields in traceContext
+  const { customContext } = context;
+
+  if (customContext.tracestate) {
+    headers.tracestate = customContext.tracestate;
+  }
+
+  return headers;
 }

--- a/lib/propagation/w3c.js
+++ b/lib/propagation/w3c.js
@@ -110,8 +110,8 @@ function httpTracePropagationHook(context = {}) {
   // add tracestate if there are fields in traceContext
   const { customContext } = context;
 
-  if (customContext.tracestate) {
-    headers.tracestate = customContext.tracestate;
+  if (customContext && Object.keys(customContext).length > 0) {
+    headers.tracestate = util.objToString(customContext);
   }
 
   return headers;

--- a/lib/propagation/w3c.js
+++ b/lib/propagation/w3c.js
@@ -30,23 +30,24 @@ exports.unmarshalTraceContext = unmarshalTraceContextv1;
 
 // v1 here refers to honeycomb, the context structure
 function unmarshalTraceContextv1(traceparent, tracestate) {
-  // pull out required fields, ... for all optional
-  // using spread operator defaults all values to undefined for invalid header values
-
   try {
-    const parsedTraceState = parseTraceParent(traceparent);
-    if (!parsedTraceState) {
+    const parsedTraceParent = parseTraceParent(traceparent);
+    if (!parsedTraceParent) {
       return;
     }
-    const { traceId, spanId } = parsedTraceState;
+    const { traceId, spanId } = parsedTraceParent;
+
+    const parsedTraceState = util.stringToObj(tracestate);
+
     return {
       traceId,
       parentSpanId: spanId,
+      customContext: parsedTraceState,
     };
   } catch (error) {
     debug(
       `error: ${error},
-       unable to parse trace header: expected string value of "traceparent", received ${header}`
+       unable to parse trace header: expected string value of "traceparent", received ${traceparent}`
     );
   }
 }
@@ -90,16 +91,17 @@ exports.httpTraceParserHook = httpTraceParserHook;
 function httpTraceParserHook(req = {}) {
   const { traceparent, tracestate } = req.headers;
 
-  return exports.unmarshalTraceContext({
-    traceparent,
-    tracestate,
-  });
+  if (!traceparent) {
+    debug("'traceparent' request header not detected");
+    return;
+  }
+
+  return exports.unmarshalTraceContext(traceparent, tracestate);
 }
 
 exports.httpTracePropagationHook = httpTracePropagationHook;
 
 function httpTracePropagationHook(context = {}) {
-  console.log(context);
   // tracestate default to undefined so it will only be included when needed
   let headers = {
     [TRACE_HTTP_HEADER]: marshalTraceContext(context),

--- a/lib/propagation/w3c.js
+++ b/lib/propagation/w3c.js
@@ -30,6 +30,7 @@ exports.unmarshalTraceContext = unmarshalTraceContextv1;
 
 // v1 here refers to honeycomb, the context structure
 function unmarshalTraceContextv1(traceparent, tracestate) {
+  let parsedTraceState;
   try {
     const parsedTraceParent = parseTraceParent(traceparent);
     if (!parsedTraceParent) {
@@ -37,7 +38,9 @@ function unmarshalTraceContextv1(traceparent, tracestate) {
     }
     const { traceId, spanId } = parsedTraceParent;
 
-    const parsedTraceState = util.stringToObj(tracestate);
+    if (tracestate) {
+      parsedTraceState = util.stringToObj(tracestate);
+    }
 
     return {
       traceId,

--- a/lib/propagation/w3c.js
+++ b/lib/propagation/w3c.js
@@ -89,14 +89,12 @@ function marshalTraceContextv1(context) {
 
 exports.httpTraceParserHook = httpTraceParserHook;
 
-// parserHook functions do not require users to pass an input
-// the instrumentation will provide the request object
-function httpTraceParserHook(req = {}) {
-  const { traceparent, tracestate } = req.headers;
+function httpTraceParserHook(httpReq) {
+  const { traceparent, tracestate } = httpReq.headers;
 
   if (!traceparent) {
     debug("'traceparent' request header not detected");
-    return;
+    return null;
   }
 
   return exports.unmarshalTraceContext(traceparent, tracestate);

--- a/lib/propagation/w3c.test.js
+++ b/lib/propagation/w3c.test.js
@@ -1,0 +1,99 @@
+/* global require describe test expect */
+const propagation = require("."),
+  schema = require("../schema"),
+  Span = require("../api/span"),
+  cases = require("jest-in-case");
+
+const { w3c } = propagation;
+
+// this context structure is the same as what the libhoney event api implementation generate.
+let testContext = {
+  id: "7f042f75651d9782dcff93a45fa99be0",
+  dataset: "testDataset",
+  stack: [new Span({ [schema.TRACE_SPAN_ID]: "c998e73e5420f609" })],
+};
+
+cases(
+  "marshaling w3c",
+  opts => expect(w3c.marshalTraceContext(opts.testContext)).toEqual(opts.header),
+  [
+    {
+      name: "non-standard headers, no custom context",
+      testContext: {
+        id: "abcdef123456",
+        dataset: "testDataset",
+        stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
+      },
+      header: "00-abcdef123456-0102030405-01",
+    },
+    {
+      name: "w3c-standard ids, custom context does not propagate in traceparent",
+      testContext: {
+        id: "7f042f75651d9782dcff93a45fa99be0",
+        dataset: "testDataset",
+        stack: [new Span({ [schema.TRACE_SPAN_ID]: "c998e73e5420f609" })],
+        traceContext: {
+          userID: 1,
+          errorMsg: "failed to sign on",
+          toRetry: true,
+        },
+      },
+      header: "00-7f042f75651d9782dcff93a45fa99be0-c998e73e5420f609-01",
+    },
+  ]
+);
+
+cases(
+  "unmarshaling w3c headers",
+  opts => expect(w3c.unmarshalTraceContext(opts.contextStr)).toEqual(opts.value),
+  [
+    {
+      name: "v00, with parent, with span, with traceflags",
+      contextStr: "00-7f042f75651d9782dcff93a45fa99be0-c998e73e5420f609-01",
+      value: {
+        parentSpanId: "c998e73e5420f609",
+        traceId: "7f042f75651d9782dcff93a45fa99be0",
+      },
+    },
+    {
+      name: "unsupported version",
+      contextStr: "99-7f042f75651d9782dcff93a45fa99be0-c998e73e5420f609-01",
+      value: undefined,
+    },
+    {
+      name: "invalid trace id",
+      contextStr: "00-00000000000000000000000000000000-c998e73e5420f609-01",
+      value: undefined,
+    },
+    {
+      name: "invalid trace id, invalid span id",
+      contextStr: "00-00000000000000000000000000000000-0000000000000000-01",
+      value: undefined,
+    },
+    {
+      name: "invalid span id",
+      contextStr: "00-7f042f75651d9782dcff93a45fa99be0-0000000000000000-01",
+      value: undefined,
+    },
+    {
+      name: "v00, missing span id",
+      contextStr: "00-7f042f75651d9782dcff93a45fa99be0-01",
+      value: undefined,
+    },
+    {
+      name: "v00, missing trace id",
+      contextStr: "00-c998e73e5420f609-01",
+      value: undefined,
+    },
+  ]
+);
+
+describe("roundtrip", () => {
+  test("works", () => {
+    let contextStr = w3c.marshalTraceContext(testContext);
+    expect(w3c.unmarshalTraceContext(contextStr)).toEqual({
+      traceId: "7f042f75651d9782dcff93a45fa99be0",
+      parentSpanId: "c998e73e5420f609",
+    });
+  });
+});

--- a/lib/propagation/w3c.test.js
+++ b/lib/propagation/w3c.test.js
@@ -18,13 +18,13 @@ cases(
   opts => expect(w3c.marshalTraceContext(opts.testContext)).toEqual(opts.header),
   [
     {
-      name: "non-standard headers, no custom context",
+      name: "don't propagate non-standard ids, no custom context",
       testContext: {
         id: "abcdef123456",
         dataset: "testDataset",
         stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
       },
-      header: "00-abcdef123456-0102030405-01",
+      header: "",
     },
     {
       name: "w3c-standard ids, custom context does not propagate in traceparent",


### PR DESCRIPTION
Adds prebuilt interop propagation hooks so configuration can look like this:

```
const beeline = require("honeycomb-beeline");

beeline({
    httpTracePropagationHook: beeline.w3c.httpTracePropagationHook,
    httpTraceParserHook: beeline.w3c.httpTraceParserHook,
});
```

This also includes a testing suite refactor from a previously closed PR.

For the AWS propagator, this includes a fallback to self (rather than parent) if parent is not present. This PR also includes utility functions for converting an object to a string for propagation, and a string to an object for ingestion. The join characters default to w3c/honeycomb (,, =) but can be overridden
