### PR TITLE
return result of spanFn even when there is no parent context

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Erwin van der Koogh
 Ally Weir
 Ashish Bista
 Mordy Tikotzky
+Randall Koutnik

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -167,8 +167,7 @@ module.exports = class LibhoneyEventAPI {
     if (!parentContext) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       this.askForIssue("no parentContext in startAsyncSpan.");
-      spanFn({});
-      return;
+      return spanFn({});
     }
     if (parentContext.stack.length > 0) {
       parentId = parentContext.stack[parentContext.stack.length - 1].payload[schema.TRACE_SPAN_ID];


### PR DESCRIPTION
There's a case where I want to asynchronously trace something but also care about the return value:

```javascript
const makeQuery = async (query) => {
  return beeline.startAsyncSpan({
    name: 'example',
  }, (span) => {
    return makeDatabaseQuery(query)
    .finally(() => beeline.finishSpan(span));
  });
};
```

This works just fine _so long as there's an active trace._  If there's no active trace, `startAsyncSpan` returns `undefined` and the whole thing falls over.  This PR ensures that the `startAsyncSpan` always returns the value returned from `spanFn`.