### PR TITLE
Support fastify v3

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -94,7 +94,7 @@ const instrumentFastify = function(fastify, opts = {}) {
         [schema.TRACE_SPAN_NAME]: "request",
         [schema.TRACE_ID_SOURCE]: spanContext.source,
         "request.host": request.hostname,
-        "request.original_url": request.req.originalUrl,
+        "request.original_url": request.raw.url,
         "request.remote_addr": request.ip,
         "request.method": request.req.method,
         "request.route": request.route ? request.route.path : undefined,
@@ -129,7 +129,9 @@ const instrumentFastify = function(fastify, opts = {}) {
         }
 
         rootSpan.addContext({
-          "response.status_code": String(reply.res.statusCode),
+          // reply.raw is used in fastify v3, fallback to reply.res for older
+          // versions
+          "response.status_code": String((reply.raw || reply.res).statusCode),
         });
         if (request.params) {
           Object.keys(request.params).forEach(param =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,9 +1216,9 @@
       "dev": true
     },
     "abstract-logging": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
-      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "dev": true
     },
     "accepts": {
@@ -1447,15 +1447,22 @@
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true
+    },
     "avvio": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-6.2.1.tgz",
-      "integrity": "sha512-k+gTocL3yShwN1PtKEsSj7eFiApcZ4JZLAu/ecyzEb8jyx+Kmxb+7SXUsodB47g7fqhs/zkfsCdqq72a1ok5Ew==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.0.tgz",
+      "integrity": "sha512-KtC63UyZARidAoIV8wXutAZnDIbZcXBqLjTAhZOX+mdMZBQCh5il/15MvCvma1178nhTwvN2D0TOAdiKG1MpUA==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "debug": "^4.0.0",
-        "fastq": "^1.6.0"
+        "fastq": "^1.6.1",
+        "queue-microtask": "^1.1.2"
       }
     },
     "aws-sign2": {
@@ -2300,9 +2307,9 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
     "define-property": {
@@ -3175,13 +3182,34 @@
       "dev": true
     },
     "fast-json-stringify": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.15.3.tgz",
-      "integrity": "sha512-p+ucnySTbrUQ9M7u8ygFIxrmpG8B+8O4/PvLDdh+RqMMgj/h6OoDb7U2lP+kqg3PDclQBFbSIArRhkorFwZLLg==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.2.9.tgz",
+      "integrity": "sha512-O8YmNoc7LnfSafVaTfa1yXVFT4UMsi/N7cYcNZw6w5D5tltyu6XGXvH45mvWfsrcFoSK+H0q0exGXsUqC18z/g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.8.1",
-        "deepmerge": "^3.0.0"
+        "ajv": "^6.11.0",
+        "deepmerge": "^4.2.2",
+        "string-similarity": "^4.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        }
       }
     },
     "fast-levenshtein": {
@@ -3190,43 +3218,63 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-redact": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.5.0.tgz",
-      "integrity": "sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
     },
     "fastify": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.6.0.tgz",
-      "integrity": "sha512-3GxGV2P8731o2S5T6ng5NMJ9S7vFpZA4mk2mJEbMbhQ5aj1HhNGBOe39TYa2gWRrJVJuXxYYYIlY/5cFhiHpNg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.7.0.tgz",
+      "integrity": "sha512-xmiR1TOSNXXNHfEvBwhWlyj158q59vZkPLIKQ71f7qJG5QMPqCbeYUUFRaDKTaLFhRqmLLFprBpJsO5nbSMiPQ==",
       "dev": true,
       "requires": {
-        "abstract-logging": "^1.0.0",
-        "ajv": "^6.9.2",
-        "avvio": "^6.1.1",
-        "fast-json-stringify": "^1.15.0",
-        "find-my-way": "^2.0.0",
+        "abstract-logging": "^2.0.0",
+        "ajv": "^6.12.2",
+        "avvio": "^7.1.2",
+        "fast-json-stringify": "^2.2.1",
+        "fastify-error": "^0.2.0",
+        "fastify-warning": "^0.2.0",
+        "find-my-way": "^3.0.0",
         "flatstr": "^1.0.12",
-        "light-my-request": "^3.2.0",
-        "middie": "^4.0.1",
-        "pino": "^5.11.1",
-        "proxy-addr": "^2.0.4",
-        "readable-stream": "^3.1.1",
-        "rfdc": "^1.1.2",
-        "secure-json-parse": "^1.0.0",
-        "tiny-lru": "^6.0.1"
+        "light-my-request": "^4.2.0",
+        "pino": "^6.2.1",
+        "proxy-addr": "^2.0.5",
+        "readable-stream": "^3.4.0",
+        "rfdc": "^1.1.4",
+        "secure-json-parse": "^2.0.0",
+        "semver": "^7.3.2",
+        "tiny-lru": "^7.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -3234,24 +3282,42 @@
             "util-deprecate": "^1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
         "string_decoder": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         }
       }
     },
+    "fastify-error": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.2.0.tgz",
+      "integrity": "sha512-zabxsBatj59ROG0fhP36zNdc5Q1/eYeH9oSF9uvfrurZf8/JKfrJbMcIGrLpLWcf89rS6L91RHWm20A/X85hcA==",
+      "dev": true
+    },
+    "fastify-warning": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
+      "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
+      "dev": true
+    },
     "fastq": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
-      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
-        "reusify": "^1.0.0"
+        "reusify": "^1.0.4"
       }
     },
     "fb-watchman": {
@@ -3336,12 +3402,12 @@
       }
     },
     "find-my-way": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.1.0.tgz",
-      "integrity": "sha512-Hdx6ctcrzkZH5y9EREHtXryXAgc5Bc8z5Cvoa61y9kaoYj2KU4yXD6h8b6u0NUkYPVmQQeRdf0AtG1kQxQ+ukQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.4.tgz",
+      "integrity": "sha512-Trl/mNAVvTgCpo9ox6yixkwiZUvecKYUQZoAuMCBACsgGqv+FbWe+jE5sBA5+U8LIWrJk/cw8zPV53GPrjTnsw==",
       "dev": true,
       "requires": {
-        "fast-decode-uri-component": "^1.0.0",
+        "fast-decode-uri-component": "^1.0.1",
         "safe-regex2": "^2.0.0",
         "semver-store": "^0.3.0"
       }
@@ -4167,9 +4233,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -6190,19 +6256,40 @@
       }
     },
     "light-my-request": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-3.4.1.tgz",
-      "integrity": "sha512-E1zMvRWjqsaCS60dTkD7c//xKV1KOFD2zo92Ru3o3e95lCfQSDCC9aS8MZm1V+zXaA/SeKDwK9gvrfaCseTusg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.2.1.tgz",
+      "integrity": "sha512-33FZvX/418IEy0sXldsLiJifbS/ruttcVveTbbZ8sQVR2VSFPA39hBu/iF/hVkt/1V0N7CdTQg4jiiVPdGgW8A==",
       "dev": true,
       "requires": {
-        "ajv": "^6.8.1",
-        "readable-stream": "^3.1.1"
+        "ajv": "^6.12.2",
+        "cookie": "^0.4.0",
+        "fastify-warning": "^0.2.0",
+        "readable-stream": "^3.6.0",
+        "set-cookie-parser": "^2.4.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -6210,13 +6297,19 @@
             "util-deprecate": "^1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
         "string_decoder": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         }
       }
@@ -6631,24 +6724,6 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "middie": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/middie/-/middie-4.0.1.tgz",
-      "integrity": "sha512-eYK6EEHZiYpQMYPmeCb/vC9ZzJg1HCqi1ot/fQs1sPZKt/XREgXouQ7g6c9J5XvDV5203JjbpovCYNkHcHgTpQ==",
-      "dev": true,
-      "requires": {
-        "path-to-regexp": "^3.0.0",
-        "reusify": "^1.0.2"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.0.0.tgz",
-          "integrity": "sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==",
           "dev": true
         }
       }
@@ -7286,23 +7361,23 @@
       }
     },
     "pino": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.0.tgz",
-      "integrity": "sha512-cYmYb1bRp1NyCvi+HBjmlsDsojnMrcn0weYgcYvg4l6Oj3zi76RlNToPvQLT59D/jGgex36pH84sB5XIQ/GYAA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.7.0.tgz",
+      "integrity": "sha512-vPXJ4P9rWCwzlTJt+f0Ni4THc3DWyt8iDDCO4edQ8narTu6hnpzdXu8FqeSJCGndl1W6lfbYQUQihUO54y66Lw==",
       "dev": true,
       "requires": {
-        "fast-redact": "^1.4.4",
-        "fast-safe-stringify": "^2.0.6",
-        "flatstr": "^1.0.9",
-        "pino-std-serializers": "^2.3.0",
-        "quick-format-unescaped": "^3.0.2",
-        "sonic-boom": "^0.7.3"
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^2.4.2",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-std-serializers": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
       "dev": true
     },
     "pirates": {
@@ -7454,13 +7529,13 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
+        "ipaddr.js": "1.9.1"
       }
     },
     "proxy-agent": {
@@ -7510,10 +7585,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
       "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
     },
+    "queue-microtask": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.0.tgz",
+      "integrity": "sha512-J95OVUiS4b8qqmpqhCodN8yPpHG2mpZUPQ8tDGyIY0VhM+kBHszOuvsMJVGNQ1OH2BnTFbqz45i+2jGpDw9H0w==",
+      "dev": true
+    },
     "quick-format-unescaped": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
-      "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
       "dev": true
     },
     "range-parser": {
@@ -8009,9 +8090,9 @@
       }
     },
     "secure-json-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-1.0.0.tgz",
-      "integrity": "sha512-kMg4jXttRQzVyLebIDc+MRxCueJ/zsmHpCn59BRd0mZUCd+V02wNd7/Pds8Nyhv7jfLHo1KkUOzdIF7cRMU4LQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.1.0.tgz",
+      "integrity": "sha512-GckO+MS/wT4UogDyoI/H/S1L0MCcKS1XX/vp48wfmU7Nw4woBmb8mIpu4zPBQjKlRT88/bt9xdoV4111jPpNJA==",
       "dev": true
     },
     "semver": {
@@ -8093,6 +8174,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-cookie-parser": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.6.tgz",
+      "integrity": "sha512-mNCnTUF0OYPwYzSHbdRdCfNNHqrne+HS5tS5xNb6yJbdP9wInV0q5xPLE0EyfV/Q3tImo3y/OXpD8Jn0Jtnjrg==",
       "dev": true
     },
     "set-value": {
@@ -8340,12 +8427,13 @@
       }
     },
     "sonic-boom": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.4.tgz",
-      "integrity": "sha512-8JRAJg0RxZtFLQMxolwETvWd2JSlH3ZGo/Z4xPxMbpqF14xCgVYPVeFCFOR3zyr3pcfG82QDVj6537Sx5ZWdNw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
+      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
       "dev": true,
       "requires": {
-        "flatstr": "^1.0.9"
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
       }
     },
     "source-map": {
@@ -8552,6 +8640,12 @@
           }
         }
       }
+    },
+    "string-similarity": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.2.tgz",
+      "integrity": "sha512-eCsPPyoQBgY4TMpVD6DVfO7pLrimUONriaO4Xjp3WPUW0YnNLqdHgRj23xotLlqrL90eJhBeq3zdAJf2mQgfBQ==",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -9002,9 +9096,9 @@
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
     },
     "tiny-lru": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-6.0.1.tgz",
-      "integrity": "sha512-k/vdHz+bFALjmik0URLWBYNuO0hCABTL5dullbZBXvFDdlL8RrKaeLR6YuHfX+6ZXOLkHw+HpNLCUA7DtLMQmg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.6.tgz",
+      "integrity": "sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==",
       "dev": true
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "eslint": "^7.11.0",
     "express": "^4.17.1",
-    "fastify": "^2.5.0",
+    "fastify": "^3.0.0",
     "husky": "^1.3.1",
     "jest": "^26.6.0",
     "jest-in-case": "^1.0.2",


### PR DESCRIPTION
Update to v3 of Fastify, the current major version.

Still supports v2 of fustily but we don't have a good way of maintaining tests for multiple versions of dependencies 😢
