### PR TITLE
Use public ENV context in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,11 +141,11 @@ workflows:
             - test
       - publish_github:
           <<: *filters_publish
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build_artifacts
       - publish_npm:
           <<: *filters_publish
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - test


### PR DESCRIPTION
We created a new context in Circle for public repos (Honeycomb Secrets for Public Repos), which is identical to the Honeycomb Secrets, with the exception of the Github token, which has more restrictive privileges (only public repos).

This will continue to allow builds to publish Github releases in the public repos, without exposing access to private repos.