### PR TITLE
Handle pg pool clients

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ Ally Weir
 Ashish Bista
 Mordy Tikotzky
 Randall Koutnik
+Mark Gaylard

--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ All contributions will be released under the Apache License 2.0.
 Use `npm version --no-git-tag-version` to update the version number using `major`, `minor`, `patch`, or the prerelease variants `premajor`, `preminor`, or `prepatch`. We use `--no-git-tag-version` to avoid automatically tagging - tagging with the version automatically triggers a CI run that publishes, and we only want to do that upon merging the PR into `main`.
 
 After doing this, follow our usual instructions for the actual process of tagging and releasing the package.
+
+## Running postgresql tests locally
+
+If you don't have postgresql running locally, you can launch postgresql in docker.
+
+```
+docker run -p 5432:5432 -e POSTGRES_USER=root circleci/postgres:9-alpine-ram
+```
+
+Then run the tests using
+
+```
+PGUSER=root PGDATABASE=postgres npm test
+```

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -124,7 +124,7 @@ let instrumentPg = function (pg, opts = {}) {
           }
 
           const r = query.apply(this, [config, values, callback]);
-          return r instanceof Promise && !callback ? promiseWrapper(span, r) : r;
+          return r instanceof Promise ? promiseWrapper(span, r) : r;
         }
       );
     };

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -46,7 +46,7 @@ const promiseWrapper = (span, promise) => {
           "db.error_hint": error.hint,
         });
       }
-      return error;
+      throw error;
     })
     .finally(() => api.finishSpan(span, "query"));
 };

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -30,6 +30,27 @@ const getQueryName = function ([config]) {
   return undefined;
 };
 
+const promiseWrapper = (span, promise) => {
+  return promise
+    .then((result) => {
+      span.addContext({
+        "db.rows_affected": result.rowCount,
+      });
+      return result;
+    })
+    .catch((error) => {
+      if (error !== null && error instanceof Error) {
+        span.addContext({
+          "db.error": error.message,
+          "db.error_stack": error.stack,
+          "db.error_hint": error.hint,
+        });
+      }
+      return error;
+    })
+    .finally(() => api.finishSpan(span, "query"));
+};
+
 const wrapper = (span, cb) => {
   return api.bindFunctionToTrace((...cb_args) => {
     const [error, result] = cb_args;
@@ -102,7 +123,8 @@ let instrumentPg = function (pg, opts = {}) {
             }
           }
 
-          return query.apply(this, [config, values, callback]);
+          const r = query.apply(this, [config, values, callback]);
+          return r instanceof Promise && !callback ? promiseWrapper(span, r) : r;
         }
       );
     };

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -5,8 +5,17 @@ const api = require("../api"),
 
 const pg = instrumentPG(require("pg"));
 
+const assertEventFields = () => {
+  const events = api._apiForTesting().sentEvents;
+  const event = events.find((e) => e.name === "query");
+  expect(event).toMatchObject({
+    "db.query": expect.any(String),
+    "db.rows_affected": 1,
+  });
+};
+
 describe("pg", () => {
-  const callback = (client, trace, done) => {
+  const callback = (client, done) => {
     return () => {
       client.end();
       const events = api._apiForTesting().sentEvents;
@@ -18,24 +27,12 @@ describe("pg", () => {
     };
   };
 
-  const resultTestingCallback = (
-    client,
-    trace,
-    done,
-    expectedResultRowZero,
-    expectedError = null
-  ) => {
+  const resultTestingCallback = (client, done, expectedResultRowZero) => {
     return (err, res) => {
-      expect(err).toEqual(expectedError);
+      expect(err === null || err === undefined).toBeTruthy();
       expect(res.rows[0]).toEqual(expectedResultRowZero);
-      client.end();
-      const events = api._apiForTesting().sentEvents;
-      const event = events.find((e) => e.name === "query");
-      expect(event).toMatchObject({
-        "db.query": expect.any(String),
-        "db.rows_affected": 1,
-      });
-      done();
+      assertEventFields();
+      client.end().then(() => done());
     };
   };
 
@@ -47,49 +44,85 @@ describe("pg", () => {
     api._resetForTesting();
   });
 
-  test("basic query with callback", (done) => {
-    const trace = api.startTrace({ name: "pg-test" });
-    const client = new pg.Client();
-    client.connect();
-    client.query("SELECT 1 as value;", resultTestingCallback(client, trace, done, { value: 1 }));
-    api.finishTrace(trace);
-  });
+  describe("basic query", () => {
+    test("with no values and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      client.query("SELECT 1 as value;", resultTestingCallback(client, done, { value: 1 }));
+      api.finishTrace(trace);
+    });
 
-  test("basic query with values and callback", (done) => {
-    const trace = api.startTrace({ name: "pg-test" });
-    const client = new pg.Client();
-    client.connect();
-    client.query(
-      "select $1::text as name;",
-      ["honeycomb"],
-      resultTestingCallback(client, trace, done, { name: "honeycomb" })
-    );
-    api.finishTrace(trace);
-  });
+    test("with values and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      client.query(
+        "select $1::text as name;",
+        ["honeycomb"],
+        resultTestingCallback(client, done, { name: "honeycomb" })
+      );
+      api.finishTrace(trace);
+    });
 
-  test("query config object with callback", (done) => {
-    const trace = api.startTrace({ name: "pg-test" });
-    const client = new pg.Client();
-    client.connect();
-    const query = {
-      text: "select $1::text as name;",
-      values: ["honeycomb"],
-    };
-    client.query(query, resultTestingCallback(client, trace, done, { name: "honeycomb" }));
-    api.finishTrace(trace);
-  });
+    test("with query config object and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      const query = {
+        text: "select $1::text as name;",
+        values: ["honeycomb"],
+      };
+      client.query(query, resultTestingCallback(client, done, { name: "honeycomb" }));
+      api.finishTrace(trace);
+    });
 
-  test("query object with internal callback", (done) => {
-    const trace = api.startTrace({ name: "pg-test" });
-    const client = new pg.Client();
-    client.connect();
-    const query = new pg.Query(
-      "select $1::text as name",
-      ["brianc"],
-      resultTestingCallback(client, trace, done, { name: "brianc" })
-    );
-    client.query(query);
-    api.finishTrace(trace);
+    test("with query object with internal callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      const query = new pg.Query(
+        "select $1::text as name",
+        ["brianc"],
+        resultTestingCallback(client, done, { name: "brianc" })
+      );
+      client.query(query);
+      api.finishTrace(trace);
+    });
+
+    test("with no values returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      client
+        .query("SELECT 2 as value;")
+        .then((result) => {
+          expect(result.rows[0]).toEqual({ value: 2 });
+          assertEventFields();
+        })
+        .finally(() => {
+          client.end();
+          api.finishTrace(trace);
+          done();
+        });
+    });
+
+    test("with values returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      client
+        .query("select $1::text as name;", ["honeycomb"])
+        .then((result) => {
+          expect(result.rows[0]).toEqual({ name: "honeycomb" });
+          assertEventFields();
+        })
+        .finally(() => {
+          client.end();
+          api.finishTrace(trace);
+          done();
+        });
+    });
   });
 
   test("pg-query-stream", (done) => {
@@ -98,8 +131,186 @@ describe("pg", () => {
     client.connect();
     const query = new QueryStream("SELECT * FROM generate_series(0, $1) num", [10]);
     const stream = client.query(query);
-    stream.on("close", callback(client, trace, done));
+    stream.on("close", callback(client, done));
     stream.on("readable", stream.read);
     api.finishTrace(trace);
+  });
+
+  describe("pool query", () => {
+    test("with no values and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.query("select 3 as value;", resultTestingCallback(pool, done, { value: 3 }));
+      api.finishTrace(trace);
+    });
+
+    test("with values and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.query(
+        "select $1::text as name;",
+        ["honeycomb"],
+        resultTestingCallback(pool, done, { name: "honeycomb" })
+      );
+      api.finishTrace(trace);
+    });
+
+    test("with query object and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      const query = {
+        text: "select $1::text as name;",
+        values: ["honeycomb"],
+      };
+      pool.query(query, resultTestingCallback(pool, done, { name: "honeycomb" }));
+      api.finishTrace(trace);
+    });
+
+    test("with no values returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool
+        .query("select 3 as value;")
+        .then((result) => {
+          expect(result.rows[0]).toEqual({ value: 3 });
+          assertEventFields();
+        })
+        .finally(() => {
+          pool.end();
+          api.finishTrace(trace);
+          done();
+        });
+    });
+
+    test("with values returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool
+        .query("select $1::text as name;", ["honeycomb"])
+        .then((result) => {
+          expect(result.rows[0]).toEqual({ name: "honeycomb" });
+          assertEventFields();
+        })
+        .finally(() => {
+          pool.end();
+          api.finishTrace(trace);
+          done();
+        });
+    });
+
+    test("with query object returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      const query = {
+        text: "select $1::text as name;",
+        values: ["honeycomb"],
+      };
+      pool
+        .query(query)
+        .then((result) => {
+          expect(result.rows[0]).toEqual({ name: "honeycomb" });
+          assertEventFields();
+        })
+        .finally(() => {
+          pool.end();
+          api.finishTrace(trace);
+          done();
+        });
+    });
+  });
+
+  describe("pool client", () => {
+    test("with no values and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) => {
+        client.query("select 4 as value;", resultTestingCallback(client, done, { value: 4 }));
+        api.finishTrace(trace);
+      });
+    });
+
+    test("with values and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) => {
+        client.query(
+          "select $1::text as name;",
+          ["honeycomb"],
+          resultTestingCallback(client, done, { name: "honeycomb" })
+        );
+        api.finishTrace(trace);
+      });
+    });
+
+    test("with query object and callback", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) => {
+        const query = {
+          text: "select $1::text as name;",
+          values: ["honeycomb"],
+        };
+        client.query(query, resultTestingCallback(client, done, { name: "honeycomb" }));
+        api.finishTrace(trace);
+      });
+    });
+
+    test("with no values returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) =>
+        client
+          .query("select 3 as value;")
+          .then((result) => {
+            expect(result.rows[0]).toEqual({ value: 3 });
+            assertEventFields();
+          })
+          .finally(() => {
+            client.release();
+            api.finishTrace(trace);
+            pool.end().then(() => done());
+          })
+      );
+    });
+
+    test("with values returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) =>
+        client
+          .query("select $1::text as name;", ["honeycomb"])
+          .then((result) => {
+            expect(result.rows[0]).toEqual({ name: "honeycomb" });
+            assertEventFields();
+          })
+          .finally(() => {
+            client.release();
+            api.finishTrace(trace);
+            pool.end().then(() => done());
+          })
+      );
+    });
+
+    test("with query object returning promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) => {
+        const query = {
+          text: "select $1::text as name;",
+          values: ["honeycomb"],
+        };
+        client
+          .query(query)
+          .then((result) => {
+            expect(result.rows[0]).toEqual({ name: "honeycomb" });
+            assertEventFields();
+          })
+          .finally(() => {
+            client.release();
+            api.finishTrace(trace);
+            pool.end().then(() => done());
+          });
+      });
+    });
   });
 });

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -18,6 +18,27 @@ describe("pg", () => {
     };
   };
 
+  const resultTestingCallback = (
+    client,
+    trace,
+    done,
+    expectedResultRowZero,
+    expectedError = null
+  ) => {
+    return (err, res) => {
+      expect(err).toEqual(expectedError);
+      expect(res.rows[0]).toEqual(expectedResultRowZero);
+      client.end();
+      const events = api._apiForTesting().sentEvents;
+      const event = events.find((e) => e.name === "query");
+      expect(event).toMatchObject({
+        "db.query": expect.any(String),
+        "db.rows_affected": 1,
+      });
+      done();
+    };
+  };
+
   beforeEach(() => {
     api.configure({ impl: "mock" });
   });
@@ -30,7 +51,7 @@ describe("pg", () => {
     const trace = api.startTrace({ name: "pg-test" });
     const client = new pg.Client();
     client.connect();
-    client.query("SELECT 1;", callback(client, trace, done));
+    client.query("SELECT 1 as value;", resultTestingCallback(client, trace, done, { value: 1 }));
     api.finishTrace(trace);
   });
 
@@ -38,7 +59,11 @@ describe("pg", () => {
     const trace = api.startTrace({ name: "pg-test" });
     const client = new pg.Client();
     client.connect();
-    client.query("select $1::text as name;", ["honeycomb"], callback(client, trace, done));
+    client.query(
+      "select $1::text as name;",
+      ["honeycomb"],
+      resultTestingCallback(client, trace, done, { name: "honeycomb" })
+    );
     api.finishTrace(trace);
   });
 
@@ -50,7 +75,7 @@ describe("pg", () => {
       text: "select $1::text as name;",
       values: ["honeycomb"],
     };
-    client.query(query, callback(client, trace, done));
+    client.query(query, resultTestingCallback(client, trace, done, { name: "honeycomb" }));
     api.finishTrace(trace);
   });
 
@@ -61,7 +86,7 @@ describe("pg", () => {
     const query = new pg.Query(
       "select $1::text as name",
       ["brianc"],
-      callback(client, trace, done)
+      resultTestingCallback(client, trace, done, { name: "brianc" })
     );
     client.query(query);
     api.finishTrace(trace);

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -159,11 +159,13 @@ describe("pg", () => {
       client.connect();
       client
         .query("SELECT 1 as value from x;")
+        .then((_) => done.fail("expected error to be thrown"))
         .catch((err) => assertErrorEventFields(err))
         .finally(() => {
           client.end().then(() => done());
           api.finishTrace(trace);
         });
+      expect.assertions(1);
     });
   });
 
@@ -272,11 +274,13 @@ describe("pg", () => {
       const pool = new pg.Pool();
       pool
         .query("SELECT 1 as value from x;")
+        .then((_) => done.fail("expected error to be thrown"))
         .catch((err) => assertErrorEventFields(err))
         .finally(() => {
           pool.end().then(() => done());
           api.finishTrace(trace);
         });
+      expect.assertions(1);
     });
   });
 
@@ -395,6 +399,7 @@ describe("pg", () => {
       pool.connect().then((client) => {
         client
           .query("SELECT 1 as value from x;")
+          .then((_) => done.fail("expected error to be thrown"))
           .catch((err) => assertErrorEventFields(err))
           .finally(() => {
             client.release();
@@ -402,6 +407,7 @@ describe("pg", () => {
             pool.end().then(() => done());
           });
       });
+      expect.assertions(1);
     });
   });
 });

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -5,14 +5,22 @@ const api = require("../api"),
 
 const pg = instrumentPG(require("pg"));
 
-const assertEventFields = () => {
+const assertEventFields = (extraFields) => {
   const events = api._apiForTesting().sentEvents;
   const event = events.find((e) => e.name === "query");
   expect(event).toMatchObject({
     "db.query": expect.any(String),
-    "db.rows_affected": 1,
+    ...extraFields,
   });
 };
+
+const assertEventFieldsWithOneRow = () => assertEventFields({ "db.rows_affected": 1 });
+const assertErrorEventFields = (err) =>
+  assertEventFields({
+    "db.error": err.message,
+    "db.error_stack": err.stack,
+    "db.error_hint": err.hint,
+  });
 
 describe("pg", () => {
   const callback = (client, done) => {
@@ -27,11 +35,20 @@ describe("pg", () => {
     };
   };
 
-  const resultTestingCallback = (client, done, expectedResultRowZero) => {
+  const successfulResultAssertingCallback = (client, done, expectedResultRowZero) => {
     return (err, res) => {
       expect(err === null || err === undefined).toBeTruthy();
       expect(res.rows[0]).toEqual(expectedResultRowZero);
-      assertEventFields();
+      assertEventFieldsWithOneRow();
+      client.end().then(() => done());
+    };
+  };
+
+  const failureResultAssertingCallback = (client, done) => {
+    return (err, res) => {
+      expect(err).toBeDefined();
+      expect(res).not.toBeDefined();
+      assertErrorEventFields(err);
       client.end().then(() => done());
     };
   };
@@ -49,7 +66,10 @@ describe("pg", () => {
       const trace = api.startTrace({ name: "pg-test" });
       const client = new pg.Client();
       client.connect();
-      client.query("SELECT 1 as value;", resultTestingCallback(client, done, { value: 1 }));
+      client.query(
+        "SELECT 1 as value;",
+        successfulResultAssertingCallback(client, done, { value: 1 })
+      );
       api.finishTrace(trace);
     });
 
@@ -60,7 +80,7 @@ describe("pg", () => {
       client.query(
         "select $1::text as name;",
         ["honeycomb"],
-        resultTestingCallback(client, done, { name: "honeycomb" })
+        successfulResultAssertingCallback(client, done, { name: "honeycomb" })
       );
       api.finishTrace(trace);
     });
@@ -73,7 +93,7 @@ describe("pg", () => {
         text: "select $1::text as name;",
         values: ["honeycomb"],
       };
-      client.query(query, resultTestingCallback(client, done, { name: "honeycomb" }));
+      client.query(query, successfulResultAssertingCallback(client, done, { name: "honeycomb" }));
       api.finishTrace(trace);
     });
 
@@ -84,7 +104,7 @@ describe("pg", () => {
       const query = new pg.Query(
         "select $1::text as name",
         ["brianc"],
-        resultTestingCallback(client, done, { name: "brianc" })
+        successfulResultAssertingCallback(client, done, { name: "brianc" })
       );
       client.query(query);
       api.finishTrace(trace);
@@ -98,12 +118,11 @@ describe("pg", () => {
         .query("SELECT 2 as value;")
         .then((result) => {
           expect(result.rows[0]).toEqual({ value: 2 });
-          assertEventFields();
+          assertEventFieldsWithOneRow();
         })
         .finally(() => {
-          client.end();
+          client.end().then(() => done());
           api.finishTrace(trace);
-          done();
         });
     });
 
@@ -115,12 +134,35 @@ describe("pg", () => {
         .query("select $1::text as name;", ["honeycomb"])
         .then((result) => {
           expect(result.rows[0]).toEqual({ name: "honeycomb" });
-          assertEventFields();
+          assertEventFieldsWithOneRow();
         })
         .finally(() => {
-          client.end();
+          client.end().then(() => done());
           api.finishTrace(trace);
-          done();
+        });
+    });
+
+    test("with callback returning error", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      client.query(
+        "SELECT 1 as value from x;",
+        failureResultAssertingCallback(client, done, { value: 1 })
+      );
+      api.finishTrace(trace);
+    });
+
+    test("returning rejected promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const client = new pg.Client();
+      client.connect();
+      client
+        .query("SELECT 1 as value from x;")
+        .catch((err) => assertErrorEventFields(err))
+        .finally(() => {
+          client.end().then(() => done());
+          api.finishTrace(trace);
         });
     });
   });
@@ -140,7 +182,7 @@ describe("pg", () => {
     test("with no values and callback", (done) => {
       const trace = api.startTrace({ name: "pg-test" });
       const pool = new pg.Pool();
-      pool.query("select 3 as value;", resultTestingCallback(pool, done, { value: 3 }));
+      pool.query("select 3 as value;", successfulResultAssertingCallback(pool, done, { value: 3 }));
       api.finishTrace(trace);
     });
 
@@ -150,7 +192,7 @@ describe("pg", () => {
       pool.query(
         "select $1::text as name;",
         ["honeycomb"],
-        resultTestingCallback(pool, done, { name: "honeycomb" })
+        successfulResultAssertingCallback(pool, done, { name: "honeycomb" })
       );
       api.finishTrace(trace);
     });
@@ -162,7 +204,7 @@ describe("pg", () => {
         text: "select $1::text as name;",
         values: ["honeycomb"],
       };
-      pool.query(query, resultTestingCallback(pool, done, { name: "honeycomb" }));
+      pool.query(query, successfulResultAssertingCallback(pool, done, { name: "honeycomb" }));
       api.finishTrace(trace);
     });
 
@@ -173,12 +215,11 @@ describe("pg", () => {
         .query("select 3 as value;")
         .then((result) => {
           expect(result.rows[0]).toEqual({ value: 3 });
-          assertEventFields();
+          assertEventFieldsWithOneRow();
         })
         .finally(() => {
-          pool.end();
+          pool.end().then(() => done());
           api.finishTrace(trace);
-          done();
         });
     });
 
@@ -189,12 +230,11 @@ describe("pg", () => {
         .query("select $1::text as name;", ["honeycomb"])
         .then((result) => {
           expect(result.rows[0]).toEqual({ name: "honeycomb" });
-          assertEventFields();
+          assertEventFieldsWithOneRow();
         })
         .finally(() => {
-          pool.end();
+          pool.end().then(() => done());
           api.finishTrace(trace);
-          done();
         });
     });
 
@@ -209,12 +249,33 @@ describe("pg", () => {
         .query(query)
         .then((result) => {
           expect(result.rows[0]).toEqual({ name: "honeycomb" });
-          assertEventFields();
+          assertEventFieldsWithOneRow();
         })
         .finally(() => {
-          pool.end();
+          pool.end().then(() => done());
           api.finishTrace(trace);
-          done();
+        });
+    });
+
+    test("with callback returning error", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.query(
+        "SELECT 1 as value from x;",
+        failureResultAssertingCallback(pool, done, { value: 1 })
+      );
+      api.finishTrace(trace);
+    });
+
+    test("returning rejected promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool
+        .query("SELECT 1 as value from x;")
+        .catch((err) => assertErrorEventFields(err))
+        .finally(() => {
+          pool.end().then(() => done());
+          api.finishTrace(trace);
         });
     });
   });
@@ -224,7 +285,10 @@ describe("pg", () => {
       const trace = api.startTrace({ name: "pg-test" });
       const pool = new pg.Pool();
       pool.connect().then((client) => {
-        client.query("select 4 as value;", resultTestingCallback(client, done, { value: 4 }));
+        client.query(
+          "select 4 as value;",
+          successfulResultAssertingCallback(client, done, { value: 4 })
+        );
         api.finishTrace(trace);
       });
     });
@@ -236,7 +300,7 @@ describe("pg", () => {
         client.query(
           "select $1::text as name;",
           ["honeycomb"],
-          resultTestingCallback(client, done, { name: "honeycomb" })
+          successfulResultAssertingCallback(client, done, { name: "honeycomb" })
         );
         api.finishTrace(trace);
       });
@@ -250,7 +314,7 @@ describe("pg", () => {
           text: "select $1::text as name;",
           values: ["honeycomb"],
         };
-        client.query(query, resultTestingCallback(client, done, { name: "honeycomb" }));
+        client.query(query, successfulResultAssertingCallback(client, done, { name: "honeycomb" }));
         api.finishTrace(trace);
       });
     });
@@ -263,7 +327,7 @@ describe("pg", () => {
           .query("select 3 as value;")
           .then((result) => {
             expect(result.rows[0]).toEqual({ value: 3 });
-            assertEventFields();
+            assertEventFieldsWithOneRow();
           })
           .finally(() => {
             client.release();
@@ -281,7 +345,7 @@ describe("pg", () => {
           .query("select $1::text as name;", ["honeycomb"])
           .then((result) => {
             expect(result.rows[0]).toEqual({ name: "honeycomb" });
-            assertEventFields();
+            assertEventFieldsWithOneRow();
           })
           .finally(() => {
             client.release();
@@ -303,8 +367,35 @@ describe("pg", () => {
           .query(query)
           .then((result) => {
             expect(result.rows[0]).toEqual({ name: "honeycomb" });
-            assertEventFields();
+            assertEventFieldsWithOneRow();
           })
+          .finally(() => {
+            client.release();
+            api.finishTrace(trace);
+            pool.end().then(() => done());
+          });
+      });
+    });
+
+    test("with callback returning error", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) => {
+        client.query(
+          "SELECT 1 as value from x;",
+          failureResultAssertingCallback(client, done, { value: 1 })
+        );
+        api.finishTrace(trace);
+      });
+    });
+
+    test("returning rejected promise", (done) => {
+      const trace = api.startTrace({ name: "pg-test" });
+      const pool = new pg.Pool();
+      pool.connect().then((client) => {
+        client
+          .query("SELECT 1 as value from x;")
+          .catch((err) => assertErrorEventFields(err))
           .finally(() => {
             client.release();
             api.finishTrace(trace);


### PR DESCRIPTION
We found an issue when calling the promise returning version of `query` on a pg-pool client. These clients seem to behave a bit differently to both the query method on both `pg.Pool` and `pg.Client`. Both of those create a callback function before the the instrumentation is invoked, but in our case, the callback is created _after_ instrumentation. The upshot is that no callback is passed to the query function instrumented by beeline, so even though the spans are started, they are never finished.

This PR adds a wrapper to promises returned by the query function to fix this issue. It also expands on the tests for the pg instrumentation by asserting that the results returned by the wrapped functions are correct. I've also added a bit to the README file to explain how to run the pg tests.