### PR TITLE
Ensure fastify instrumentation honors the httpParserHook config

### DIFF
--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -8,6 +8,7 @@ const request = require("supertest"),
   schema = require("../schema"),
   api = require("../api"),
   tracker = require("../async_tracker"),
+  hooks = require("../propagation/hooks"),
   pkg = require(path.join(__dirname, "..", "..", "package.json"));
 
 describe("userContext", () => {
@@ -285,12 +286,52 @@ describe("Trace ids from X-Request-ID and X-Amzn-trace-id headers", () => {
   });
 });
 
+describe("trace parser hook", () => {
+  const express = instrumentExpress(require("express"));
+
+  let app;
+
+  function initializeTestApp() {
+    app = express();
+    app.get("/", function (req, res) {
+      res.status(200).send("ok");
+    });
+  }
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+    hooks.configure({
+      httpTraceParserHook: () => {
+        return { traceId: "my-special-trace" };
+      },
+    });
+    initializeTestApp();
+  });
+  afterEach(() => {
+    api._resetForTesting();
+    hooks.configure({});
+  });
+
+  test("honors the hook configuration over default parsing", (done) => {
+    request(app)
+      .get("/")
+      .set("X-Amzn-Trace-Id", "Root=1-67891233-abcdef012345678912345678")
+      .expect(200, () => {
+        expect(api._apiForTesting().sentEvents.length).toBe(1);
+        let ev = api._apiForTesting().sentEvents[0];
+        expect(ev[schema.TRACE_ID]).toBe("my-special-trace");
+        done();
+      });
+  });
+});
+
 describe("trace id callback", () => {
   const express = instrumentExpress(require("express"), {
     traceIdSource: (req) => req.get("X-Request-ID") || "efgh456",
   });
 
   let app;
+
   function initializeTestApp() {
     app = express();
     app.get("/", function (req, res) {

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -72,7 +72,7 @@ const instrumentFastify = function (fastify, opts = {}) {
       // start our trace handling
 
       // parse incoming trace headers into a span context
-      let spanContext = traceUtil.getTraceContext(traceIdSource, request);
+      let spanContext = traceUtil.parseTraceHeader(traceIdSource, request);
 
       // parentSpanId refers to the span id of the parent span
       let parentSpanId = traceUtil.getParentSourceId(parentIdSource, request);

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -5,6 +5,7 @@ const request = require("supertest"),
   cases = require("jest-in-case"),
   schema = require("../schema"),
   api = require("../api"),
+  hooks = require("../propagation/hooks"),
   pkg = require(path.join(__dirname, "..", "..", "package.json"));
 
 describe("userContext", () => {
@@ -201,6 +202,50 @@ describe("request id from http headers", () => {
       traceIdSource: api.REQUEST_ID_HTTP_HEADER,
     },
   ]);
+});
+
+describe("trace parser hook", () => {
+  const fastify = instrumentFastify(require("fastify"));
+
+  function initializeTestServer() {
+    return new Promise((resolve, reject) => {
+      const app = fastify();
+      app.get("/", function (req, res) {
+        // don't add req.user here
+        res.code(200).send("ok");
+      });
+
+      app.ready().then(() => resolve(app), reject);
+    });
+  }
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+    hooks.configure({
+      httpTraceParserHook: () => {
+        return { traceId: "my-special-trace" };
+      },
+    });
+  });
+  afterEach(() => {
+    api._resetForTesting();
+    hooks.configure({});
+  });
+
+  test("honors the hook configuration over default parsing", (done) => {
+    initializeTestServer().then((app) => {
+      request(app.server)
+        .get("/")
+        .set("X-Amzn-Trace-Id", "Root=1-67891233-abcdef012345678912345678")
+        .expect(200, () => {
+          const sentEvents = api._apiForTesting().sentEvents;
+          expect(sentEvents.length).toBe(2);
+          let ev = api._apiForTesting().sentEvents[1];
+          expect(ev[schema.TRACE_ID]).toBe("my-special-trace");
+          app.close(done);
+        });
+    });
+  });
 });
 
 describe("trace id callback", () => {


### PR DESCRIPTION
* add test for this case to both fastify and express instrumentations

Fastify instrumentation was using `traceUtils.getTraceContext` which does not use `httpTraceParserHook` configuration.