### PR TITLE
Use the non-deprecated request.raw attribute

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -96,10 +96,10 @@ const instrumentFastify = function (fastify, opts = {}) {
         "request.host": request.hostname,
         "request.original_url": request.raw.url,
         "request.remote_addr": request.ip,
-        "request.method": request.req.method,
+        "request.method": request.raw.method,
         "request.route": request.route ? request.route.path : undefined,
         "request.query": request.query,
-        "request.http_version": `HTTP/${request.req.httpVersion}`,
+        "request.http_version": `HTTP/${request.raw.httpVersion}`,
       };
 
       for (let [key, value] of Object.entries(traceUtil.getInstrumentedRequestHeaders())) {


### PR DESCRIPTION
* looks like request.req has been aliased to raw for a while: https://github.com/fastify/fastify/commit/4cb0a4b20a0d9bc6a6ffa6901b6b0d3c09f41a29
* this should continue to work for older versions of fastify, and no longer show a deprecation warning
* verified that fields are populated in Honeycomb with latest 3.x and a 2.0.0 fastify

Addresses #271 