### PR TITLE
Fix api.addContext so it works on the current span (not the root)

### DIFF
--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -648,6 +648,76 @@ test("async spans share custom context", () => {
   expect(asyncData["app.custom"]).toBe("value");
 });
 
+test("addContext works on the current span", () => {
+  const honey = api._apiForTesting().honey;
+
+  let parentSpan = api.startTrace({ name: "parent" });
+  api.addContext({ field: "a" });
+
+  let childSpan = api.startSpan({ name: "child" });
+  api.addContext({ field: "b" });
+
+  let grandchildSpan = api.startSpan({ name: "grandchild" });
+  api.addContext({ field: "c" });
+
+  api.finishSpan(grandchildSpan);
+  api.finishSpan(childSpan);
+  api.finishTrace(parentSpan);
+
+  expect(honey.transmission.events.length).toBe(3);
+
+  let parentEvent = honey.transmission.events[2].postData;
+  let childEvent = honey.transmission.events[1].postData;
+  let grandchildEvent = honey.transmission.events[0].postData;
+
+  expect(parentEvent["name"]).toBe("parent");
+  expect(childEvent["name"]).toBe("child");
+  expect(grandchildEvent["name"]).toBe("grandchild");
+
+  expect(parentEvent["field"]).toBe("a");
+  expect(childEvent["field"]).toBe("b");
+  expect(grandchildEvent["field"]).toBe("c");
+});
+
+test("removeContext works on the current span", () => {
+  const honey = api._apiForTesting().honey;
+
+  let parentSpan = api.startTrace({ name: "parent" });
+  api.addContext({ a: 1, b: 2 });
+  api.removeContext("b");
+
+  let childSpan = api.startSpan({ name: "child" });
+  api.addContext({ b: 2, c: 3 });
+  api.removeContext("c");
+
+  let grandchildSpan = api.startSpan({ name: "grandchild" });
+  api.addContext({ c: 3, d: 4 });
+  api.removeContext("d");
+
+  api.finishSpan(grandchildSpan);
+  api.finishSpan(childSpan);
+  api.finishTrace(parentSpan);
+
+  expect(honey.transmission.events.length).toBe(3);
+
+  let parentEvent = honey.transmission.events[2].postData;
+  let childEvent = honey.transmission.events[1].postData;
+  let grandchildEvent = honey.transmission.events[0].postData;
+
+  expect(parentEvent["name"]).toBe("parent");
+  expect(childEvent["name"]).toBe("child");
+  expect(grandchildEvent["name"]).toBe("grandchild");
+
+  expect(parentEvent["a"]).toBe(1);
+  expect(parentEvent["b"]).toBeUndefined();
+
+  expect(childEvent["b"]).toBe(2);
+  expect(childEvent["c"]).toBeUndefined();
+
+  expect(grandchildEvent["c"]).toBe(3);
+  expect(grandchildEvent["d"]).toBeUndefined();
+});
+
 describe("presend hook", () => {
   it("calls the presend hook function if provided", () => {
     const mockPresendHook = jest.fn();

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -290,7 +290,7 @@ module.exports = class LibhoneyEventAPI {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    Object.assign(context.stack[0].payload, map);
+    Object.assign(context.stack[context.stack.length - 1].payload, map);
   }
 
   /**
@@ -302,7 +302,7 @@ module.exports = class LibhoneyEventAPI {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    delete context.stack[0].payload[key];
+    delete context.stack[context.stack.length - 1].payload[key];
   }
 
   addTraceContext(map) {

--- a/lib/api/mock.js
+++ b/lib/api/mock.js
@@ -85,7 +85,7 @@ module.exports = class MockEventAPI {
     if (!context || context.stack.length === 0) {
       return;
     }
-    Object.assign(context.stack[0], map);
+    Object.assign(context.stack[context.stack.length - 1], map);
   }
 
   /**
@@ -93,7 +93,7 @@ module.exports = class MockEventAPI {
    */
   removeContext(key) {
     let context = tracker.getTracked();
-    delete context.stack[0].payload[key];
+    delete context.stack[context.stack.length - 1].payload[key];
   }
 
   addTraceContext(map) {


### PR DESCRIPTION
The documented behavior for `api.addContext` is that it adds fields to
the current span. However, the code was accessing index 0 of the context
stack, which will always be the *root* span. Tests previously did not
catch this because `api.addContext` was only exercised in a single-span
trace. A similar issue exists for `api.removeContext`, although it's
deprecated. But the patch is simple, so I applied it to both functions.

This probably wasn't caught sooner because `span.addContext` gets used
way more, particularly with asynchronous spans. As evidence, the
auto-instrumentation does not use `api.addContext` at all!

Note that running npm automatically bumped the package-lock.json, since
v2.7.0 of the Beeline had been released without changing the lock file.