### PR TITLE
Make api.withTrace's type signature match api.startTrace

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -100,8 +100,21 @@ module.exports = {
   finishTrace(trace) {
     return apiImpl.finishTrace(trace);
   },
-  withTrace(metadataContext, fn, withTraceId, withParentSpanId, withDataset) {
-    const trace = apiImpl.startTrace(metadataContext, withTraceId, withParentSpanId, withDataset);
+  withTrace(
+    metadataContext,
+    fn,
+    withTraceId,
+    withParentSpanId,
+    withDataset,
+    propagatedContext = {}
+  ) {
+    const trace = apiImpl.startTrace(
+      metadataContext,
+      withTraceId,
+      withParentSpanId,
+      withDataset,
+      propagatedContext
+    );
     try {
       return fn();
     } finally {

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -724,3 +724,14 @@ test("traceContext, no prefix on incoming trace context, dataset behaves as expe
   // dataset goes through as expected
   expect(honey.transmission.events[0].dataset).toBe("test_dataset");
 });
+
+test("addTraceContext works inside of withTrace", () => {
+  const honey = api._apiForTesting().honey;
+
+  api.withTrace({ name: "trace" }, () => {
+    api.addTraceContext({ foo: "bar" });
+  });
+
+  expect(honey.transmission.events.length).toBe(1);
+  expect(honey.transmission.events[0].postData["app.foo"]).toBe("bar");
+});

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -114,7 +114,8 @@ declare namespace beeline {
       fn: SpanFn<F>,
       traceId?: string,
       parentSpanId?: string,
-      dataset?: string
+      dataset?: string,
+      propagatedContext?: MetadataContext
     ): F;
 
     startSpan(metadataContext?: MetadataContext): Span | undefined;


### PR DESCRIPTION
Previously, `api.withTrace` did not accept a `propagatedContext`
parameter, so the call to `apiImpl.startTrace` was pushing a context
stack record with an `undefined` trace context. This would break
`api.addTraceContext` with the error:

    honeycomb-beeline/lib/api/libhoney.js:314
      Object.assign(context.traceContext, map);
             ^
    TypeError: Cannot convert undefined or null to object

This patch fixes the issue by making the type signature of
`api.withTrace` match that of `api.startTrace`, thereby giving the
`propagatedContext` parameter a default value that gets passed along.

`api.addTraceContext` isn't exercised very thoroughly by the tests
as-is, but I added a quick regression test for the synchronous API bug.