### PR TITLE
docs: show how to import beeline in TypeScript

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,8 +16,7 @@ const beeline = require("honeycomb-beeline")();
 Or in TypeScript:
 
 ```typescript
-import honeycomb from "honeycomb-beeline";
-const beeline = honeycomb();
+import beeline = require('honeycomb-beeline');
 
 /* beeline.traceActive() works, as do all the other calls below */
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,15 @@ const beeline = require("honeycomb-beeline")();
 /* beeline.traceActive() works, as do all the other calls below */
 ```
 
+Or in TypeScript:
+
+```typescript
+import honeycomb from "honeycomb-beeline";
+const beeline = honeycomb();
+
+/* beeline.traceActive() works, as do all the other calls below */
+```
+
 Contents
 
 1.  [Traces and spans](#traces-and-spans)


### PR DESCRIPTION
If you use `require` you don't get any of the TypeScript support