### PR TITLE
Add node 16 to test matrix, switch to non-legacy circle images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ filters_publish: &filters_publish
 matrix_nodeversions: &matrix_nodeversions
   matrix:
     parameters:
-      nodeversion: ["9", "10", "11", "12", "14", "15"]
+      nodeversion: ["10.24", "12.22", "14.17", "15.14", "16.2"]
 
 # Default version of node to use for lint and publishing
-default_nodeversion: &default_nodeversion "12"
+default_nodeversion: &default_nodeversion "12.22"
 
 executors:
   node:
@@ -31,7 +31,7 @@ executors:
         type: string
         default: *default_nodeversion
     docker:
-      - image: circleci/node:<< parameters.nodeversion >>
+      - image: cimg/node:<< parameters.nodeversion >>
         environment:
           PGUSER: root
           PGDATABASE: circle_test


### PR DESCRIPTION
See https://github.com/honeycombio/libhoney-js/pull/135 for reasons to switch to `cimg` and dropping older odd versions.