### PR TITLE
Made sampleRate optional in the interface

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -3,7 +3,7 @@ import { IncomingMessage } from "http";
 declare namespace beeline {
 
   export interface SamplerResponse {
-    sampleRate: number;
+    sampleRate?: number;
     shouldSample: boolean;
   }
 


### PR DESCRIPTION
According to the documentation, `sampleRate` parameter is supposed to be optional. 
> A custom samplerHook must return an object with this structure:
> 
> ```javascript 
> {
>   shouldSample: boolean, // false will drop the event, true will keep it
>   sampleRate: number // optional, will be reported to honeycomb
> }



The only place i could find the `sampleRate` being read from the `SamplerResponse` interface is in `lib/api/libhoney.js:273` which is being checked with a typeof number.