### PR TITLE
Use collection names for MongoDB spans.

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -41,7 +41,7 @@ function instrumentMongodb(mongodb, opts = {}) {
         let callback = populatedArgs.pop(); // we'll put this back on (wrapped) when we original.apply below
         let options = populatedArgs[populatedArgs.length - 1];
 
-        let eventName = `collection.${name}`;
+        let eventName = `${this.collectionName}.${name}`;
 
         return api.startAsyncSpan(
           {


### PR DESCRIPTION
It's much more useful to see `users.findOne` than `collection.findOne`. I'll update tests once/if https://github.com/honeycombio/beeline-nodejs/pull/393 is merged.