### PR TITLE
Use JSON.stringify only when debugging is enabled

### DIFF
--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -198,7 +198,7 @@ module.exports = class LibhoneyEventAPI {
   }
 
   finishSpan(span, rollup) {
-    debug(`finishing span ${JSON.stringify(span)}`);
+    debug("finishing span %j", span);
     const context = tracker.getTracked();
     if (!context) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
@@ -262,11 +262,11 @@ module.exports = class LibhoneyEventAPI {
       });
 
       if (this.samplerHook) {
-        debug(`executing sampler hook on event ev = ${JSON.stringify(ev.data)}`);
+        debug("executing sampler hook on event ev = %j", ev.data);
         const samplerHookResponse = this.samplerHook(ev.data);
         const keepEvent = samplerHookResponse.shouldSample;
         if (!keepEvent) {
-          debug(`skipping event due to sampler hook sample ev = ${JSON.stringify(ev.data)}`);
+          debug("skipping event due to sampler hook sample ev = %j", ev.data);
           return;
         }
 
@@ -276,11 +276,11 @@ module.exports = class LibhoneyEventAPI {
       }
 
       if (this.presendHook) {
-        debug(`executing presend hook on event ev = ${JSON.stringify(ev.data)}`);
+        debug("executing presend hook on event ev = %j", ev.data);
         this.presendHook(ev);
       }
 
-      debug(`enqueuing presampled event ev = ${JSON.stringify(ev.data)}`);
+      debug("enqueuing presampled event ev = %j", ev.data);
       ev.sendPresampled();
     });
   }


### PR DESCRIPTION
There's no need to call `JSON.stringify` for every finished span when debugging is disabled. It can be done lazily.

If `JSON.stringify` takes 0.1ms on average then for 50 spans we get 5ms added to the overall latency.