### PR TITLE
Support esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This package makes it easy to instrument your Express/NodeJS application to send
 
 - **Node 10+**
 
+## Known Issues
+
+- Using a bundler (esbuild, webpack, etc.) with the Beeline is unsupported. You may be able to use the Beeline with a bundler, but auto-instrumentations will likely not work.
+
 ## Contributions
 
 Features, bug fixes and other changes to `beeline-nodejs` are gladly accepted. Please

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,10 +1,9 @@
 /* eslint-env node */
-const path = require("path"),
-  process = require("process"),
+const process = require("process"),
   schema = require("../schema"),
   propagation = require("../propagation"),
   tracker = require("../async_tracker"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+  pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:event`),
   LibhoneyImpl = require("./libhoney"),
   MockImpl = require("./mock");

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -1,11 +1,10 @@
 /* eslint-env node, jest */
-const path = require("path"),
-  api = require("."),
+const api = require("."),
   schema = require("../schema"),
   tracker = require("../async_tracker"),
   propagation = require("../propagation"),
   deterministicSampler = require("../deterministic_sampler"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json"));
+  pkg = require("../../package.json");
 
 jest.mock("../deterministic_sampler");
 

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -2,7 +2,6 @@
 const libhoney = require("libhoney"),
   os = require("os"),
   process = require("process"),
-  path = require("path"),
   url = require("url"),
   crypto = require("crypto"),
   tracker = require("../async_tracker"),
@@ -10,7 +9,7 @@ const libhoney = require("libhoney"),
   deterministicSampler = require("../deterministic_sampler"),
   schema = require("../schema"),
   Span = require("./span"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+  pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:event`);
 
 const defaultName = "nodejs";

--- a/lib/api/mock.js
+++ b/lib/api/mock.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
-const path = require("path"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+const pkg = require("../../package.json"),
   tracker = require("../async_tracker"),
   schema = require("../schema"),
   Span = require("./span");

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -6,31 +6,26 @@ const shimmer = require("shimmer"),
   pkg = require("../package.json"),
   debug = require("debug")(`${pkg.name}:instrumentation`);
 
-const instrumentations = [
-  "bluebird",
-  "child_process",
-  "express",
-  "fastify",
-  "http",
-  "https",
-  "mongodb",
-  "mongoose",
-  "mpromise",
-  "mysql2",
-  "pg",
-  "react-dom/server",
-  "sequelize",
-];
+const instrumentations = {
+  bluebird: () => require("./instrumentation/bluebird"),
+  child_process: () => require("./instrumentation/child_process"),
+  express: () => require("./instrumentation/express"),
+  fastify: () => require("./instrumentation/fastify"),
+  http: () => require("./instrumentation/http"),
+  https: () => require("./instrumentation/https"),
+  mongodb: () => require("./instrumentation/mongodb"),
+  mongoose: () => require("./instrumentation/mongoose"),
+  mpromise: () => require("./instrumentation/mpromise"),
+  mysql2: () => require("./instrumentation/mysql2"),
+  pg: () => require("./instrumentation/pg"),
+  "react-dom/server": () => require("./instrumentation/react-dom-server"),
+  sequelize: () => require("./instrumentation/sequelize"),
+};
 
-let enabledInstrumentations = new Set(instrumentations);
+let enabledInstrumentations = new Set(Object.keys(instrumentations));
 const instrumentedPaths = new Map();
 const instrumentationsActive = new Set();
 exports.activeInstrumentations = () => Array.from(instrumentationsActive.keys()).sort();
-
-const instrumentationPath = (name) => {
-  name = name.replace(/\//g, "-");
-  return `${__dirname}/instrumentation/${name}`;
-};
 
 let preloadDone = false;
 const instrumentPreload = (exports.instrumentPreload = () => {
@@ -104,7 +99,7 @@ const instrumentLoad = (exports.instrumentLoad = (mod, loadRequest, parent, opts
 
   // set instrumentation as the instrumentation function i.e. instrumentHTTP
   // and require it
-  let instrumentation = require(instrumentationPath(loadRequest));
+  let instrumentation = instrumentations[loadRequest]();
   let new_mod;
 
   try {
@@ -167,10 +162,10 @@ exports.configure = (opts = {}) => {
   instrumentPreload();
 };
 
-exports.getInstrumentations = () => instrumentations.slice();
+exports.getInstrumentations = () => Object.keys(instrumentations).slice();
 
 exports.clearInstrumentationForTesting = () => {
-  enabledInstrumentations = new Set(instrumentations);
+  enabledInstrumentations = new Set(Object.keys(instrumentations));
   instrumentationsActive.clear();
   instrumentedPaths.clear();
 };

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -3,8 +3,7 @@ const shimmer = require("shimmer"),
   tracker = require("./async_tracker"),
   Module = require("module"),
   process = require("process"),
-  path = require("path"),
-  pkg = require(path.join(__dirname, "..", "package.json")),
+  pkg = require("../package.json"),
   debug = require("debug")(`${pkg.name}:instrumentation`);
 
 const instrumentations = [

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -7,8 +7,7 @@ const onHeaders = require("on-headers"),
   api = require("../api"),
   util = require("../util"),
   traceUtil = require("./trace-util"),
-  path = require("path"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+  pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:express`);
 
 const slice = Array.prototype.slice;

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -1,6 +1,5 @@
 /* eslint-env node, jest */
 const request = require("supertest"),
-  path = require("path"),
   http = require("http"),
   net = require("net"),
   instrumentExpress = require("./express"),
@@ -9,7 +8,7 @@ const request = require("supertest"),
   api = require("../api"),
   tracker = require("../async_tracker"),
   hooks = require("../propagation/hooks"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json"));
+  pkg = require("../../package.json");
 
 describe("userContext", () => {
   function runCase(opts, done) {

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -4,8 +4,7 @@ const shimmer = require("shimmer"),
   schema = require("../schema"),
   api = require("../api"),
   traceUtil = require("./trace-util"),
-  path = require("path"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+  pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:fastify`);
 
 const slice = Array.prototype.slice;

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -1,12 +1,11 @@
 /* eslint-env node, jest */
 const request = require("supertest"),
-  path = require("path"),
   instrumentFastify = require("./fastify"),
   cases = require("jest-in-case"),
   schema = require("../schema"),
   api = require("../api"),
   hooks = require("../propagation/hooks"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json"));
+  pkg = require("../../package.json");
 
 describe("userContext", () => {
   function runCase(opts, done) {

--- a/lib/propagation/honeycomb.js
+++ b/lib/propagation/honeycomb.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
-const path = require("path"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+const pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:propagation`),
   util = require("./util");
 

--- a/lib/propagation/hooks.js
+++ b/lib/propagation/hooks.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
-const path = require("path"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+const pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:event`);
 
 let httpTraceParserHook;

--- a/lib/propagation/w3c.js
+++ b/lib/propagation/w3c.js
@@ -2,8 +2,7 @@
 // requiring the OTEL trace header key from the api
 // as well as the parser
 const { TRACE_PARENT_HEADER, parseTraceParent } = require("@opentelemetry/core"),
-  path = require("path"),
-  pkg = require(path.join(__dirname, "..", "..", "package.json")),
+  pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:propagation:w3c`),
   util = require("./util");
 


### PR DESCRIPTION
After applying the changes in this PR, I was able to generate traces from a bundle using esbuild. I have not tested webpack, since I don't use it, but this should at least partially address #172.

My test app manually calls `startTrace`/`finishTrace` and uses Node's `http` library. You can see below that, once restructured, esbuild is able to handle the `require` calls for instrumentation:

```
$ esbuild --bundle lib/index.js --platform=node | grep 'instrumentations = {' -A 14
    var instrumentations = {
      bluebird: () => require_bluebird(),
      child_process: () => require_child_process(),
      express: () => require_express(),
      fastify: () => require_fastify(),
      http: () => require_http2(),
      https: () => require_https2(),
      mongodb: () => require_mongodb(),
      mongoose: () => require_mongoose(),
      mpromise: () => require_mpromise(),
      mysql2: () => require_mysql2(),
      pg: () => require_pg(),
      "react-dom/server": () => require_react_dom_server(),
      sequelize: () => require_sequelize()
    };
```

**EDIT:** In practice, this means that, although honeycomb-beeline can now be used from esbuild bundles, the only auto-instrumentations supported will be for built-in libraries (at least when used with `--platform=node`). See this comment for details: https://github.com/honeycombio/beeline-nodejs/pull/415#issuecomment-907116116