### PR TITLE
Add engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "https://github.com/honeycombio/beeline-nodejs.git"
   },
+  "engines": {
+    "node": ">= 10.*"
+  },
   "bugs": {
     "url": "https://github.com/honeycombio/beeline-nodejs/issues"
   },


### PR DESCRIPTION
Updates https://github.com/honeycombio/telemetry-team/issues/2

From https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines

> Unless the user has set the engine-strict config flag, this field is advisory only and will only produce warnings when your package is installed as a dependency.