### PR TITLE
Update deprecation comments

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -55,11 +55,22 @@ module.exports = {
   },
 
   REQUEST_ID_HTTP_HEADER: propagation.REQUEST_ID_HTTP_HEADER,
+  /**
+   * @deprecated use provider-specific functions, e.g. honeycomb.marshalTraceContext
+   */
   marshalTraceContext: honeycomb.marshalTraceContext,
 
-  // deprecated. Use provider-specific functions and constants
+  /**
+   * @deprecated use provider-specific constants, e.g. honeycomb.TRACE_HTTP_HEADER
+   */
   TRACE_HTTP_HEADER: honeycomb.TRACE_HTTP_HEADER,
+  /**
+   * @deprecated use aws.TRACE_HTTP_HEADER
+   */
   AMAZON_TRACE_HTTP_HEADER: aws.TRACE_HTTP_HEADER,
+  /**
+   * @deprecated use provider-specific functions, e.g. honeycomb.unmarshalTraceContext
+   */
   unmarshalTraceContext: propagation.unmarshalTraceContext,
 
   honeycomb: {
@@ -169,8 +180,9 @@ module.exports = {
     return apiImpl.addContext(map);
   },
 
-  // DEPRECATED
-  // next major bump will remove this.  No replacement.
+  /**
+   * @deprecated will be removed in the next major release
+   */
   removeContext(key) {
     return apiImpl.removeContext(key);
   },
@@ -180,6 +192,9 @@ module.exports = {
   // next major bump will remove this.  No replacement for `.customContext.remove`,
   // and `.addTraceContext` below will the way to handle `.customContext.add`
   customContext: {
+    /**
+     * @deprecated use .addTraceContext()
+     */
     add(key, val) {
       let map;
 
@@ -191,6 +206,9 @@ module.exports = {
 
       return apiImpl.addTraceContext(mapFieldsToApp(map));
     },
+    /**
+     * @deprecated will be removed in the next major release
+     */
     remove(key) {
       return apiImpl.removeTraceContext(schema.customContext(key));
     },

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -293,8 +293,9 @@ module.exports = class LibhoneyEventAPI {
     Object.assign(context.stack[0].payload, map);
   }
 
-  // DEPRECATED
-  // next major bump will remove this.  No replacement.
+  /**
+   * @deprecated will be removed in the next major release
+   */
   removeContext(key) {
     const context = tracker.getTracked();
     if (!context || context.stack.length === 0) {
@@ -313,8 +314,9 @@ module.exports = class LibhoneyEventAPI {
     Object.assign(context.traceContext, map);
   }
 
-  // DEPRECATED
-  // next major bump will remove this.  No replacement.
+  /**
+   * @deprecated will be removed in the next major release
+   */
   removeTraceContext(key) {
     const context = tracker.getTracked();
     if (!context) {

--- a/lib/api/mock.js
+++ b/lib/api/mock.js
@@ -88,8 +88,9 @@ module.exports = class MockEventAPI {
     Object.assign(context.stack[0], map);
   }
 
-  // DEPRECATED
-  // next major bump will remove this.  No replacement.
+  /**
+   * @deprecated will be removed in the next major release
+   */
   removeContext(key) {
     let context = tracker.getTracked();
     delete context.stack[0].payload[key];
@@ -99,8 +100,9 @@ module.exports = class MockEventAPI {
     Object.assign(this.traceContext, map);
   }
 
-  // DEPRECATED
-  // next major bump will remove this.  No replacement.
+  /**
+   * @deprecated will be removed in the next major release
+   */
   removeTraceContext(key) {
     delete this.traceContext[key];
   }

--- a/lib/propagation/index.js
+++ b/lib/propagation/index.js
@@ -8,13 +8,15 @@ const honeycomb = require("./honeycomb"),
 exports.REQUEST_ID_HTTP_HEADER = "X-Request-ID";
 
 // VERSION points to honeycomb.VERSION for backwards compatibility.
-
-// Deprecated: Use honeycomb.VERSION
+/**
+ * @deprecated [internal] use honeycomb.VERSION
+ */
 exports.VERSION = honeycomb.VERSION;
 
 // unmarshalTraceContext wraps honeycomb.unmarshalTraceContext for backwards compatibility.
-
-// Deprecated: Use honeycomb.unmarshalTraceContext
+/**
+ * @deprecated [internal] use honeycomb.unmarshalTraceContext
+ */
 exports.unmarshalTraceContext = unmarshalTraceContext;
 
 function unmarshalTraceContext(traceHeader) {
@@ -22,8 +24,9 @@ function unmarshalTraceContext(traceHeader) {
 }
 
 // marshalTraceContext wraps honeycomb.marshalTraceContext for backwards compatibility.
-
-// Deprecated: Use honeycomb.marshalTraceContext
+/**
+ * @deprecated [internal] use honeycomb.marshalTraceContext
+ */
 exports.marshalTraceContext = marshalTraceContext;
 
 function marshalTraceContext(context) {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -147,9 +147,9 @@ declare namespace beeline {
 
     getInstrumentations(): string[];
 
-    /** @deprecated this method will be removed in the next major release. Please use honeycomb.marshalTraceContext() instead. */
+    /** @deprecated use provider-specific functions, e.g. honeycomb.marshalTraceContext */
     marshalTraceContext(ctx: MarshallableContext): string;
-    /** @deprecated this method will be removed in the next major release. Please use honeycomb.unmarshalTraceContext() instead. */
+    /** @deprecated use provider-specific functions, e.g. honeycomb.unmarshalTraceContext */
     unmarshalTraceContext(ctx: string): TraceContext | undefined;
 
     honeycomb: {
@@ -176,7 +176,7 @@ declare namespace beeline {
       TRACE_HTTP_HEADER: string;
     };
 
-    /** @deprecated this constant will be removed in the next major release. Please use honeycomb.TRACE_HTTP_HEADER instead. */
+    /** @deprecated use provider-specific constants, e.g. honeycomb.TRACE_HTTP_HEADER */
     TRACE_HTTP_HEADER: string;
   }
 }

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -17,6 +17,7 @@ declare namespace beeline {
 
     samplerHook?(event: unknown): SamplerResponse;
     presendHook?(event: unknown): void;
+    /** @deprecated use enabledInstrumentations: [] */
     disableInstrumentation?: boolean;
 
     express?: {


### PR DESCRIPTION
JSDoc is better for code analysis tools to warn about using deprecated methods -- this can go out as a patch release prior to the major release that removes those functions