### PR TITLE
Stop auto-detecting x-request-id and amazon trace headers

### DIFF
--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -59,9 +59,7 @@ exports.getTraceContext = (traceIdSource, req) => {
   const { honeycomb, aws } = api;
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
-      typeof traceIdSource === "undefined"
-        ? [honeycomb.TRACE_HTTP_HEADER, "X-Request-ID", aws.TRACE_HTTP_HEADER]
-        : [traceIdSource];
+      typeof traceIdSource === "undefined" ? [honeycomb.TRACE_HTTP_HEADER] : [traceIdSource];
     let valueAndHeader = getValueFromHeaders(req.headers, headers);
 
     if (!valueAndHeader) {


### PR DESCRIPTION
- breaking change
- users will have to opt-in to custom trace propagation
- no more missing root spans for users with uninstrumented amazon load balancers

[Initial PR](https://github.com/honeycombio/beeline-nodejs/pull/194) that intended to make this change
[Docs update](https://github.com/honeycombio/docs/pull/647) for the missing root spans that result from auto-detection
