### PR TITLE
Fix types on bindFunctionToTrace

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -141,7 +141,8 @@ declare namespace beeline {
       remove(k: string): void;
     };
 
-    bindFunctionToTrace<F>(fn: SpanFn<F>): F;
+    // bindFunctionToTrace<F>(fn: SpanFn<F>): F;
+    bindFunctionToTrace<T>(fn:T): T;
     runWithoutTrace<F>(fn: SpanFn<F>): F;
 
     flush(): Promise<void>;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -141,7 +141,6 @@ declare namespace beeline {
       remove(k: string): void;
     };
 
-    // bindFunctionToTrace<F>(fn: SpanFn<F>): F;
     bindFunctionToTrace<T>(fn:T): T;
     runWithoutTrace<F>(fn: SpanFn<F>): F;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #423 

## Short description of the changes

- This change is restricted to only the types, not actual functionality within the beeline... and aligns with the actual behavior of the function.
- Previously, `bindFunctionToTrace` would take any function and return the result of executing the function. Now it should simply return the type of the argument that was passed in. 
