### PR TITLE
remove unnecessary dependency on node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.2",
     "@opentelemetry/core": "^1.0.0",
-    "@types/node": "^16.3.2",
     "array-flatten": "^3.0.0",
     "debug": "^4.2.0",
     "libhoney": "^2.2.1",


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- dependency on `@types/node` was accidentally introduced with the types definition file

## Short description of the changes

- verified in a TS test app that beeline still works
