### PR TITLE
Expand type definitions to include all libhoney options

### DIFF
--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -83,6 +83,13 @@ module.exports = class LibhoneyEventAPI {
 
     this.defaultDataset = opts.dataset || process.env["HONEYCOMB_DATASET"] || defaultName;
 
+    const libhoneyOpts = getFilteredOptions(opts);
+
+    let userAgentAddition = `honeycomb-beeline/${pkg.version}`;
+    if (libhoneyOpts.userAgentAddition) {
+      userAgentAddition += " " + libhoneyOpts.userAgentAddition;
+    }
+
     this.honey = new libhoney(
       Object.assign(
         {
@@ -90,9 +97,9 @@ module.exports = class LibhoneyEventAPI {
           proxy,
           dataset: this.defaultDataset,
           writeKey: process.env["HONEYCOMB_WRITEKEY"],
-          userAgentAddition: `honeycomb-beeline/${pkg.version}`,
         },
-        getFilteredOptions(opts)
+        libhoneyOpts,
+        { userAgentAddition }
       )
     );
     this.honey.add({

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -8,15 +8,32 @@ declare namespace beeline {
   }
 
   export interface BeelineOpts {
+    // Options passed through to libhoney
+    apiHost?: string;
+    proxy?: string;
     writeKey?: string;
     dataset?: string;
-    serviceName?: string;
     sampleRate?: number;
+    batchSizeTrigger?: number;
+    batchTimeTrigger?: number;
+    maxConcurrentBatches?: number;
+    pendingWorkCapacity?: number;
+    maxResponseQueueSize?: number;
+    timeout?: number;
+    disabled?: false;
+    userAgentAddition?: string;
+    transmission?: string;
+
+    // Beeline-specific options
+    serviceName?: string;
     enabledInstrumentations?: string[];
     impl?: "libhoney-event" | "mock";
 
     samplerHook?(event: unknown): SamplerResponse;
     presendHook?(event: unknown): void;
+    httpTraceParserHook?: HttpTraceParserHook;
+    httpTracePropagationHook?: HttpTracePropagationHook;
+
     /** @deprecated use enabledInstrumentations: [] */
     disableInstrumentation?: boolean;
 
@@ -35,10 +52,6 @@ declare namespace beeline {
     mongodb?: {
       includeDocuments?: boolean;
     };
-
-    httpTraceParserHook?: HttpTraceParserHook;
-    httpTracePropagationHook?: HttpTracePropagationHook;
-    transmission?: string;
   }
 
   export interface Schema {


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- The typescript type defininition is currently missing some fields that the beeline will pass through to libhoney

## Short description of the changes

This adds all parameters documented in libhoney to the typescript definition.

The specific one I wanted to use was `apiHost`, but I figured I'd add them all while I was here.

`userAgentAddition` is now special-cased, so that the beeline addition is still included if the option is supplied.
