### PR TITLE
Further improvements to typescript types

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -85,7 +85,7 @@ declare namespace beeline {
     startTimeHR: [number, number];
   }
 
-  export type MetadataContext = Record<string, unknown>;
+  export type MetadataContext = Record<string, any>;
 
   export interface TraceContext {
     traceId?: string;
@@ -153,7 +153,7 @@ declare namespace beeline {
     addContext(metadataContext: MetadataContext): void;
 
     bindFunctionToTrace<T extends AnyFunction>(fn:T): T;
-    runWithoutTrace<T extends AnyFunction>(fn:T): T;
+    runWithoutTrace<T extends AnyFunction>(fn:T): ReturnType<T>;
 
     flush(): Promise<void>;
 
@@ -183,6 +183,12 @@ declare namespace beeline {
       TRACE_HTTP_HEADER: string;
     };
 
+    /**
+     * When using the "mock" implementation, _apiForTesting() can be used to
+     * inspect the events that would have been sent.
+     *
+     * As the name implies, this should only be used for testing purposes.
+     */
     _apiForTesting(): {
       sentEvents: Span["payload"][];
       traceId: number;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -7,6 +7,12 @@ declare namespace beeline {
     shouldSample: boolean;
   }
 
+  export interface libhoneyEvent {
+    data: Record<string, unknown>;
+    add(data: Record<string, unknown>): this;
+    addField(key: string, value: unknown): this;
+  }
+
   export interface BeelineOpts {
     // Options passed through to libhoney
     apiHost?: string;
@@ -29,8 +35,8 @@ declare namespace beeline {
     enabledInstrumentations?: string[];
     impl?: "libhoney-event" | "mock";
 
-    samplerHook?(event: unknown): SamplerResponse;
-    presendHook?(event: unknown): void;
+    samplerHook?(event: libhoneyEvent): SamplerResponse;
+    presendHook?(event: libhoneyEvent): void;
     httpTraceParserHook?: HttpTraceParserHook;
     httpTracePropagationHook?: HttpTracePropagationHook;
 
@@ -103,7 +109,7 @@ declare namespace beeline {
     startTimeHR: [number, number];
   }
 
-  type SpanFn<F> = (...args: any[]) => F;
+  type SpanFn<F> = (span: Span) => F;
 
   type Configure = (opts?: BeelineOpts) => Beeline & Configure;
 
@@ -145,8 +151,8 @@ declare namespace beeline {
     addTraceContext(metadataContext: MetadataContext): void;
     addContext(metadataContext: MetadataContext): void;
 
-    bindFunctionToTrace<T>(fn:T): T;
-    runWithoutTrace<F>(fn: SpanFn<F>): F;
+    bindFunctionToTrace<T extends Function>(fn:T): T;
+    runWithoutTrace<T extends Function>(fn:T): T;
 
     flush(): Promise<void>;
 
@@ -176,6 +182,10 @@ declare namespace beeline {
       TRACE_HTTP_HEADER: string;
     };
 
+    _apiForTesting(): {
+      sentEvents: Span["payload"][];
+      traceId: number;
+    };
   }
 }
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -7,7 +7,7 @@ declare namespace beeline {
     shouldSample: boolean;
   }
 
-  export interface libhoneyEvent {
+  export interface LibhoneyEvent {
     data: Record<string, unknown>;
     add(data: Record<string, unknown>): this;
     addField(key: string, value: unknown): this;
@@ -35,8 +35,8 @@ declare namespace beeline {
     enabledInstrumentations?: string[];
     impl?: "libhoney-event" | "mock";
 
-    samplerHook?(event: libhoneyEvent): SamplerResponse;
-    presendHook?(event: libhoneyEvent): void;
+    samplerHook?(event: LibhoneyEvent): SamplerResponse;
+    presendHook?(event: LibhoneyEvent): void;
     httpTraceParserHook?: HttpTraceParserHook;
     httpTracePropagationHook?: HttpTracePropagationHook;
 
@@ -85,7 +85,7 @@ declare namespace beeline {
     startTimeHR: [number, number];
   }
 
-  export type MetadataContext = Record<string, any>;
+  export type MetadataContext = Record<string, unknown>;
 
   export interface TraceContext {
     traceId?: string;
@@ -110,6 +110,7 @@ declare namespace beeline {
   }
 
   type SpanFn<F> = (span: Span) => F;
+  type AnyFunction = (...args: unknown[]) => unknown;
 
   type Configure = (opts?: BeelineOpts) => Beeline & Configure;
 
@@ -151,8 +152,8 @@ declare namespace beeline {
     addTraceContext(metadataContext: MetadataContext): void;
     addContext(metadataContext: MetadataContext): void;
 
-    bindFunctionToTrace<T extends Function>(fn:T): T;
-    runWithoutTrace<T extends Function>(fn:T): T;
+    bindFunctionToTrace<T extends AnyFunction>(fn:T): T;
+    runWithoutTrace<T extends AnyFunction>(fn:T): T;
 
     flush(): Promise<void>;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Fixes #507 

## Short description of the changes

* expose `_apiForTesting`
* provide event type to sample/presend hooks
* include the Span type for SpanFn (previously this typed `span` as `any`)
