### PR TITLE
feat: accept both w3c and honeycomb propagation headers by default

### DIFF
--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -1,26 +1,8 @@
 /* eslint-env node */
-const api = require("../api");
-const propagation = require("../propagation");
-
-// returns the header name/value for the first header with a value in the request.
-const getValueFromHeaders = (requestHeaders, headers) => {
-  let value, header;
-
-  for (const h of headers) {
-    let headerValue = requestHeaders[h.toLowerCase()];
-    if (headerValue) {
-      header = h; // source = `${h} http header`;
-      value = headerValue;
-      break;
-    }
-  }
-
-  if (typeof value !== "undefined") {
-    return { value, header };
-  }
-
-  return undefined;
-};
+const api = require("../api"),
+  propagation = require("../propagation"),
+  pkg = require("../../package.json"),
+  debug = require("debug")(`${pkg.name}:event`);
 
 // adds trace source field to the context and returns the updated context
 function _includeSource(context, key) {
@@ -56,16 +38,35 @@ exports.propagateTraceHeader = () => {
 // parse a trace header and return object used to populate args to startTrace
 // deprecated: in the next major version this should get renamed to getSpanContext
 exports.getTraceContext = (traceIdSource, req) => {
-  const { honeycomb, aws } = api;
+  const { honeycomb, w3c } = api;
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
-    let headers =
-      typeof traceIdSource === "undefined" ? [honeycomb.TRACE_HTTP_HEADER] : [traceIdSource];
-    let valueAndHeader = getValueFromHeaders(req.headers, headers);
+    let header, value;
 
-    if (!valueAndHeader) {
+    if (typeof traceIdSource !== "undefined") {
+      header = traceIdSource;
+      value = req.headers[traceIdSource.toLowerCase()];
+    } else {
+      const honeycombHeaderValue = req.headers[honeycomb.TRACE_HTTP_HEADER.toLowerCase()];
+      const w3cHeaderValue = req.headers[w3c.TRACE_HTTP_HEADER.toLowerCase()];
+
+      if (honeycombHeaderValue && w3cHeaderValue) {
+        debug("warn: received both honeycomb and w3c propagation headers, preferring honeycomb.");
+      }
+
+      if (honeycombHeaderValue) {
+        header = honeycomb.TRACE_HTTP_HEADER;
+        value = honeycombHeaderValue;
+      } else if (w3cHeaderValue) {
+        header = w3c.TRACE_HTTP_HEADER;
+        value = w3cHeaderValue;
+      }
+    }
+
+    if (!value && !header) {
+      // couldn't find trace context
       return {};
     }
-    let { value, header } = valueAndHeader;
+
     let parsed = {};
     switch (header) {
       //honeycomb trace header
@@ -75,9 +76,9 @@ exports.getTraceContext = (traceIdSource, req) => {
         return _includeSource(parsed, header);
       }
 
-      case aws.TRACE_HTTP_HEADER: {
-        header = aws.TRACE_HTTP_HEADER;
-        parsed = aws.unmarshalTraceContext(value);
+      case w3c.TRACE_HTTP_HEADER: {
+        header = w3c.TRACE_HTTP_HEADER;
+        parsed = w3c.unmarshalTraceContext(value);
         return _includeSource(parsed, header);
       }
 

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -38,7 +38,7 @@ exports.propagateTraceHeader = () => {
 // parse a trace header and return object used to populate args to startTrace
 // deprecated: in the next major version this should get renamed to getSpanContext
 exports.getTraceContext = (traceIdSource, req) => {
-  const { honeycomb, w3c } = api;
+  const { honeycomb, w3c, aws } = api;
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let header, value;
 
@@ -79,6 +79,12 @@ exports.getTraceContext = (traceIdSource, req) => {
       case w3c.TRACE_HTTP_HEADER: {
         header = w3c.TRACE_HTTP_HEADER;
         parsed = w3c.unmarshalTraceContext(value);
+        return _includeSource(parsed, header);
+      }
+
+      case aws.TRACE_HTTP_HEADER: {
+        header = aws.TRACE_HTTP_HEADER;
+        parsed = aws.unmarshalTraceContext(value);
         return _includeSource(parsed, header);
       }
 

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -62,7 +62,7 @@ exports.getTraceContext = (traceIdSource, req) => {
       }
     }
 
-    if (!value && !header) {
+    if (!value) {
       // couldn't find trace context
       return {};
     }

--- a/lib/instrumentation/trace-util.test.js
+++ b/lib/instrumentation/trace-util.test.js
@@ -10,54 +10,13 @@ function getRequestWithHeader(name, value) {
   return req;
 }
 
+function getRequestWithHeaders(headers) {
+  const req = new http.IncomingMessage();
+  headers.forEach((h) => (req.headers[h.name.toLowerCase()] = h.value));
+  return req;
+}
+
 describe("getTraceContext", () => {
-  cases(
-    "AWS X-Ray trace header",
-    (opts) => {
-      expect(
-        traceUtil.getTraceContext(
-          "X-Amzn-Trace-Id",
-          getRequestWithHeader("X-Amzn-Trace-Id", opts.headerVal)
-        )
-      ).toEqual(opts.expectedContext);
-    },
-    [
-      {
-        name: "root / no parent",
-        headerVal: "Root=1-67891233-abcdef012345678912345678",
-        expectedContext: {
-          traceId: "1-67891233-abcdef012345678912345678",
-          parentSpanId: "1-67891233-abcdef012345678912345678",
-          source: "X-Amzn-Trace-Id http header",
-        },
-      },
-      {
-        name: "root / parent",
-        headerVal: "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8",
-        expectedContext: {
-          traceId: "1-5759e988-bd862e3fe1be46a994272793",
-          parentSpanId: "53995c3f42cd8ad8",
-          source: "X-Amzn-Trace-Id http header",
-        },
-      },
-      {
-        name: "self / root / no parent",
-        headerVal:
-          "Parent=1-5983f5c9-36d365bc453d28036a63032b;Root=1-5983f5c9-56dcf0bc6d4d214d2dbbe8c6",
-        expectedContext: {
-          parentSpanId: "1-5983f5c9-36d365bc453d28036a63032b",
-          traceId: "1-5983f5c9-56dcf0bc6d4d214d2dbbe8c6",
-          source: "X-Amzn-Trace-Id http header",
-        },
-      },
-      {
-        // shouldn't happen at least with aws generated headers, but if we're missing a Root= clause, we aren't in a trace at all.
-        name: "no root / parent",
-        headerVal: "Parent=53995c3f42cd8ad8",
-        expectedContext: {},
-      },
-    ]
-  );
   cases(
     "beeline trace header",
     (opts) => {
@@ -84,6 +43,64 @@ describe("getTraceContext", () => {
         name: "v1, missing trace_id",
         contextStr: "1;parent_id=12345",
         expectedContext: {},
+      },
+    ]
+  );
+  cases(
+    "w3c trace header fallback",
+    (opts) => {
+      expect(
+        traceUtil.getTraceContext(
+          undefined,
+          getRequestWithHeader(api.w3c.TRACE_HTTP_HEADER, opts.headerVal)
+        )
+      ).toEqual(opts.expectedContext);
+    },
+    [
+      {
+        name: "w3c trace_id + parent_id, missing context",
+        headerVal: "00-7f042f75651d9782dcff93a45fa99be0-c998e73e5420f609-01",
+        expectedContext: {
+          traceId: "7f042f75651d9782dcff93a45fa99be0",
+          parentSpanId: "c998e73e5420f609",
+          customContext: undefined,
+          dataset: undefined,
+          source: "traceparent http header",
+        },
+      },
+    ]
+  );
+  cases(
+    "if both honeycomb and w3c, choose honeycomb",
+    (opts) => {
+      expect(
+        traceUtil.getTraceContext(
+          undefined,
+          getRequestWithHeaders([
+            {
+              name: api.w3c.TRACE_HTTP_HEADER,
+              value: opts.w3cHeaderVal,
+            },
+            {
+              name: api.honeycomb.TRACE_HTTP_HEADER,
+              value: opts.beelineHeaderVal,
+            },
+          ])
+        )
+      ).toEqual(opts.expectedContext);
+    },
+    [
+      {
+        name: "we got both honeycomb and w3c, this should not happen",
+        w3cHeaderVal: "00-7f042f75651d9782dcff93a45fa99be0-c998e73e5420f609-01",
+        beelineHeaderVal: "1;trace_id=abcdefbeelineahh,parent_id=12345",
+        expectedContext: {
+          traceId: "abcdefbeelineahh",
+          parentSpanId: "12345",
+          customContext: undefined,
+          dataset: undefined,
+          source: "X-Honeycomb-Trace http header",
+        },
       },
     ]
   );

--- a/lib/propagation/hooks.js
+++ b/lib/propagation/hooks.js
@@ -21,8 +21,8 @@ function parseFromRequest(req) {
     // if no hook specified, try to handle as w3c
     if (w3c.TRACE_HTTP_HEADER) {
       try {
-        const parsed = w3c.httpTraceParserHook(req);
-        return parsed;
+        httpTraceParserHook = w3c.httpTraceParserHook(req);
+        return httpTraceParserHook;
       } catch (error) {
         debug(`tried to parse as w3c, but got error: ${error}`);
         return;

--- a/lib/propagation/hooks.js
+++ b/lib/propagation/hooks.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 const pkg = require("../../package.json"),
+  propagation = require("../propagation"),
   debug = require("debug")(`${pkg.name}:event`);
 
 let httpTraceParserHook;
@@ -15,8 +16,18 @@ function configure(opts = {}) {
 exports.parseFromRequest = parseFromRequest;
 
 function parseFromRequest(req) {
+  const { w3c } = propagation;
   if (!httpTraceParserHook) {
-    return;
+    // if no hook specified, try to handle as w3c
+    if (w3c.TRACE_HTTP_HEADER) {
+      try {
+        const parsed = w3c.httpTraceParserHook(req);
+        return parsed;
+      } catch (error) {
+        debug(`tried to parse as w3c, but got error: ${error}`);
+        return;
+      }
+    }
   }
 
   try {

--- a/lib/propagation/hooks.js
+++ b/lib/propagation/hooks.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
 const pkg = require("../../package.json"),
-  propagation = require("../propagation"),
   debug = require("debug")(`${pkg.name}:event`);
 
 let httpTraceParserHook;
@@ -16,18 +15,8 @@ function configure(opts = {}) {
 exports.parseFromRequest = parseFromRequest;
 
 function parseFromRequest(req) {
-  const { w3c } = propagation;
   if (!httpTraceParserHook) {
-    // if no hook specified, try to handle as w3c
-    if (w3c.TRACE_HTTP_HEADER) {
-      try {
-        httpTraceParserHook = w3c.httpTraceParserHook(req);
-        return httpTraceParserHook;
-      } catch (error) {
-        debug(`tried to parse as w3c, but got error: ${error}`);
-        return;
-      }
-    }
+    return;
   }
 
   try {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #491 

## Short description of the changes

- Currently, a user needs to set `beeline.w3c.httpTraceParserHook` to properly handle distributed tracing across mixed environments of Beeline and OpenTelemetry. This change attempts to parse an incoming request as w3c even if no httpTraceParserHook is provided, by checking for existence of w3c header and falling back to that if found (instead of just falling back to honeycomb).
- If somehow both honeycomb and w3c headers are found, honeycomb is used and a warning is emitted when debug is enabled.

co-authored by @vreynolds and @robbkidd 