### PR TITLE
add docker-compose config for test-worthy Postgres

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  pg:
+    image: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: ${USER}
+    ports:
+      - "127.0.0.1:5432:5432"


### PR DESCRIPTION
This is enough docker and postgres to make the PG instrumentation tests happy(ier).