### PR TITLE
maint: clean up tests to reduce code duplication and fragility

### DIFF
--- a/lib/instrumentation/child_process.test.js
+++ b/lib/instrumentation/child_process.test.js
@@ -11,7 +11,12 @@ function newMockContext() {
 
 instrumentChildProcess(child_process);
 
-beforeAll(() => api.configure({ impl: "mock" }));
+beforeEach(() => {
+  api.configure({ impl: "mock" });
+});
+afterEach(() => {
+  api._resetForTesting();
+});
 
 test("exec 'echo hi' works", (done) => {
   tracker.setTracked(newMockContext());

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -10,6 +10,13 @@ const request = require("supertest"),
   hooks = require("../propagation/hooks"),
   pkg = require("../../package.json");
 
+beforeEach(() => {
+  api.configure({ impl: "mock" });
+});
+afterEach(() => {
+  api._resetForTesting();
+});
+
 describe("userContext", () => {
   function runCase(opts, done) {
     const express = instrumentExpress(require("express"), opts);
@@ -27,7 +34,6 @@ describe("userContext", () => {
       });
     }
 
-    api.configure({ impl: "mock" });
     initializeTestApp();
 
     expect(express.__wrapped).toBe(true);
@@ -63,7 +69,6 @@ describe("userContext", () => {
             "response.status_code": "200",
           })
         );
-        api._resetForTesting();
         done();
       });
   }
@@ -103,11 +108,7 @@ describe("userContext as function", () => {
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     initializeTestApp();
-  });
-  afterEach(() => {
-    api._resetForTesting();
   });
 
   test("it's called even if req.user is undefined", (done) => {
@@ -142,11 +143,7 @@ describe("req properties should only be read after a request matches a route", (
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     initializeTestApp();
-  });
-  afterEach(() => {
-    api._resetForTesting();
   });
 
   test("it correctly sends the matched path", (done) => {
@@ -191,11 +188,7 @@ describe("request id from x-request-id http header", () => {
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     initializeTestApp();
-  });
-  afterEach(() => {
-    api._resetForTesting();
   });
 
   test("X-Request-ID works", (done) => {
@@ -227,11 +220,7 @@ describe("Trace ids from X-Amzn-trace-id header", () => {
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     initializeTestApp();
-  });
-  afterEach(() => {
-    api._resetForTesting();
   });
 
   test("X-Amzn-Trace-Id works", (done) => {
@@ -263,11 +252,7 @@ describe("Trace ids from X-Request-ID and X-Amzn-trace-id headers", () => {
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     initializeTestApp();
-  });
-  afterEach(() => {
-    api._resetForTesting();
   });
 
   test("X-Request-ID > X-Amzn-Trace-Id", (done) => {
@@ -298,7 +283,6 @@ describe("trace parser hook", () => {
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     hooks.configure({
       httpTraceParserHook: () => {
         return { traceId: "my-special-trace" };
@@ -307,7 +291,6 @@ describe("trace parser hook", () => {
     initializeTestApp();
   });
   afterEach(() => {
-    api._resetForTesting();
     hooks.configure({});
   });
 
@@ -340,11 +323,7 @@ describe("trace id callback", () => {
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     initializeTestApp();
-  });
-  afterEach(() => {
-    api._resetForTesting();
   });
 
   test("returns supplied X-Request-Id (calling the traceIdSource function)", (done) => {
@@ -380,11 +359,9 @@ describe("tracking loss detection", () => {
 
   let askForIssue;
   beforeAll(() => {
-    api.configure({ impl: "mock" });
     askForIssue = api._askForIssue;
   });
   afterAll(() => {
-    api._resetForTesting();
     api._askForIssue = askForIssue;
   });
 

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -7,6 +7,13 @@ const request = require("supertest"),
   hooks = require("../propagation/hooks"),
   pkg = require("../../package.json");
 
+beforeEach(() => {
+  api.configure({ impl: "mock" });
+});
+afterEach(() => {
+  api._resetForTesting();
+});
+
 describe("userContext", () => {
   function runCase(opts, done) {
     const fastify = instrumentFastify(require("fastify"), opts);
@@ -28,7 +35,6 @@ describe("userContext", () => {
       });
     }
 
-    api.configure({ impl: "mock" });
     initializeTestApp().then((app) => {
       request(app.server)
         .get("/")
@@ -70,7 +76,6 @@ describe("userContext", () => {
               }),
             ])
           );
-          api._resetForTesting();
           app.close(done);
         });
     });
@@ -116,7 +121,6 @@ describe("userContext as function", () => {
   }
 
   test("it's called even if req.user is undefined", (done) => {
-    api.configure({ impl: "mock" });
     initializeTestServer().then((app) => {
       request(app.server)
         .get("/")
@@ -125,7 +129,6 @@ describe("userContext as function", () => {
           expect(api._apiForTesting().sentEvents.length).toBe(2);
           let ev = api._apiForTesting().sentEvents[1]; // the request span
           expect(ev["request.user.random"]).toBe("stuff");
-          api._resetForTesting();
           app.close(done);
         });
     });
@@ -153,7 +156,6 @@ describe("request id from http headers", () => {
       });
     }
 
-    api.configure({ impl: "mock" });
     initializeTestServer().then((app) => {
       let r = request(app.server).get("/");
 
@@ -169,7 +171,6 @@ describe("request id from http headers", () => {
         expect(ev[schema.TRACE_ID]).toBe(opts.expectedHeaderValue);
         expect(ev[schema.TRACE_ID_SOURCE]).toBe(`${opts.expectedHeaderName} http header`);
 
-        api._resetForTesting();
         app.close(done);
       });
     });
@@ -219,7 +220,6 @@ describe("trace parser hook", () => {
   }
 
   beforeEach(() => {
-    api.configure({ impl: "mock" });
     hooks.configure({
       httpTraceParserHook: () => {
         return { traceId: "my-special-trace" };
@@ -227,7 +227,6 @@ describe("trace parser hook", () => {
     });
   });
   afterEach(() => {
-    api._resetForTesting();
     hooks.configure({});
   });
 
@@ -265,7 +264,6 @@ describe("trace id callback", () => {
       });
     }
 
-    api.configure({ impl: "mock" });
     initializeTestServer().then((app) => {
       let r = request(app.server).get("/");
 
@@ -281,7 +279,6 @@ describe("trace id callback", () => {
         expect(ev[schema.TRACE_ID]).toBe(opts.expectedTraceId);
         expect(ev[schema.TRACE_ID_SOURCE]).toBe(opts.expectedTraceIdSource);
 
-        api._resetForTesting();
         app.close(done);
       });
     });

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -5,6 +5,13 @@ const api = require("../api"),
 
 const pg = instrumentPG(require("pg"));
 
+beforeEach(() => {
+  api.configure({ impl: "mock" });
+});
+afterEach(() => {
+  api._resetForTesting();
+});
+
 const assertEventFields = (extraFields) => {
   const events = api._apiForTesting().sentEvents;
   const event = events.find((e) => e.name === "query");
@@ -52,14 +59,6 @@ describe("pg", () => {
       client.end().then(() => done());
     };
   };
-
-  beforeEach(() => {
-    api.configure({ impl: "mock" });
-  });
-
-  afterEach(() => {
-    api._resetForTesting();
-  });
 
   describe("basic query", () => {
     test("with no values and callback", (done) => {

--- a/lib/instrumentation/react-dom-server.test.js
+++ b/lib/instrumentation/react-dom-server.test.js
@@ -8,8 +8,11 @@ const ReactDOMServer = require("react-dom/server"),
 
 instrumentReactDOMServer(ReactDOMServer);
 
-beforeAll(() => {
+beforeEach(() => {
   api.configure({ impl: "mock" });
+});
+afterEach(() => {
+  api._resetForTesting();
 });
 
 describe("renderToString", () => {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #518 

## Short description of the changes

- Use `beforeEach()` to configure the api instead of manually configuring for various tests.
- Use `afterEach()` to clear the api implementation after each test

Changes are intended to help with reducing code duplication and reducing fragility in tests; it also helps with consistency. Some tests were configuring the same implementation multiple times, and some reset the implementation on some tests but not others. Files not changed either didn't use `api`, didn't configure the `api` implementation, or already had this setup.