### PR TITLE
fix: check parent exists during instrumentation:

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -71,7 +71,7 @@ function getPackageVersion(request, options) {
 }
 
 const instrumentLoad = (exports.instrumentLoad = (mod, loadRequest, parent, opts = {}) => {
-  if (parent.id.includes(`node_modules/${pkg.name}`) || !enabledInstrumentations.has(loadRequest)) {
+  if (!parent || parent.id.includes(`node_modules/${pkg.name}`) || !enabledInstrumentations.has(loadRequest)) {
     // no magic here
     return mod;
   }

--- a/lib/instrumentation.test.js
+++ b/lib/instrumentation.test.js
@@ -102,3 +102,11 @@ test("we keep track of the active instrumentations in a sorted array", () => {
   // activeInstrumentations now includes child_process
   expect(instrumentation.activeInstrumentations()).toEqual(["child_process", "express"]);
 });
+
+test("don't instrument module if parent is null", () => {
+  instrumentation.clearInstrumentationForTesting();
+  let fakeExpress = createFakeExpress();
+  let m = instrumentation.instrumentLoad(fakeExpress, "express", null);
+  expect(m).toBe(fakeExpress);
+  expect(m.__wrapped).toBeUndefined();
+});


### PR DESCRIPTION
## Which problem is this PR solving?

`parent` can be null depending on how a module was loaded, see:
https://github.com/nodejs/modules/issues/469

Particularly in nextjs a config file is loaded that causes `parent` to be null and fail the app from building with:

```
> Build error occurred
TypeError: Cannot read property 'id' of undefined // if (parent.id.includes(`node_modules/${pkg.name}`) || !enabledInstrumentations.has(loadRequest)) {
    at exports.instrumentLoad (/path/node_modules/honeycomb-beeline/lib/instrumentation.js:74:14)
    at Function._load (/path/node_modules/honeycomb-beeline/lib/instrumentation.js:158:16)
    at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)
    at ModuleJob.run (internal/modules/esm/module_job.js:183:25)
    at async Loader.import (internal/modules/esm/loader.js:178:24) {
  type: 'TypeError'
}
```

## Short description of the changes

- Skip instrumentation if `parent` is not defined for a module
