### PR TITLE
Fix `samplerHook` argument type

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,7 +1,6 @@
 import { IncomingMessage } from "http";
 
 declare namespace beeline {
-
   export interface SamplerResponse {
     sampleRate?: number;
     shouldSample: boolean;
@@ -35,7 +34,7 @@ declare namespace beeline {
     enabledInstrumentations?: string[];
     impl?: "libhoney-event" | "mock";
 
-    samplerHook?(event: LibhoneyEvent): SamplerResponse;
+    samplerHook?(event: LibhoneyEvent["data"]): SamplerResponse;
     presendHook?(event: LibhoneyEvent): void;
     httpTraceParserHook?: HttpTraceParserHook;
     httpTracePropagationHook?: HttpTracePropagationHook;
@@ -156,8 +155,8 @@ declare namespace beeline {
     addTraceContext(metadataContext: MetadataContext): void;
     addContext(metadataContext: MetadataContext): void;
 
-    bindFunctionToTrace<T extends AnyFunction>(fn:T): T;
-    runWithoutTrace<T extends AnyFunction>(fn:T): ReturnType<T>;
+    bindFunctionToTrace<T extends AnyFunction>(fn: T): T;
+    runWithoutTrace<T extends AnyFunction>(fn: T): ReturnType<T>;
 
     flush(): Promise<void>;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The type for `samplerHook` argument is incorrect. `samplerHook` directly gets the event's data, not the event itself

See here for implementation:
https://github.com/honeycombio/beeline-nodejs/blob/e2ff1791d062dc7061787c672556ffa56f2322b4/lib/api/libhoney.js#L270-L272

## Short description of the changes

- Fixes the types to match the implementation
