### PR TITLE
Make api.addContext work in impl:mock mode

### DIFF
--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -330,7 +330,8 @@ module.exports = class LibhoneyEventAPI {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    Object.assign(context.stack[context.stack.length - 1].payload, map);
+    const span = context.stack[context.stack.length - 1];
+    span.addContext(map);
   }
 
   addTraceContext(map) {

--- a/lib/api/mock.js
+++ b/lib/api/mock.js
@@ -85,7 +85,8 @@ module.exports = class MockEventAPI {
     if (!context || context.stack.length === 0) {
       return;
     }
-    Object.assign(context.stack[context.stack.length - 1], map);
+    const span = context.stack[context.stack.length - 1];
+    span.addContext(map);
   }
 
   addTraceContext(map) {


### PR DESCRIPTION
## Which problem is this PR solving?

- the `addContext` API wasn't working when using `impl: mock`
- it appeared to still be adding fields to the span in the "old way"

## Short description of the changes

- updated the `libhoney` backend to use `span.addContext` under the hood, and then synced the `mock` backend to match

There were no existing tests for the `mock` backend, so I haven't added any new ones.
