### PR TITLE
Add meta.span_type to root/subroot spans

### DIFF
--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -829,7 +829,6 @@ test("addTraceContext works inside of withTrace", () => {
 });
 
 test("startTrace without parent ID sets meta.span_type as root", () => {
-  const honey = api._apiForTesting().honey;
   expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
 
   let rootSpan = api.startTrace();
@@ -838,7 +837,6 @@ test("startTrace without parent ID sets meta.span_type as root", () => {
 });
 
 test("startTrace with parent ID sets meta.span_type as subroot", () => {
-  const honey = api._apiForTesting().honey;
   expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
 
   let rootSpan = api.startTrace({}, "traceId", "parentSpanId");

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -827,3 +827,21 @@ test("addTraceContext works inside of withTrace", () => {
   expect(honey.transmission.events.length).toBe(1);
   expect(honey.transmission.events[0].postData["app.foo"]).toBe("bar");
 });
+
+test("startTrace without parent ID sets meta.span_type as root", () => {
+  const honey = api._apiForTesting().honey;
+  expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
+
+  let rootSpan = api.startTrace();
+
+  expect(rootSpan.payload[schema.META_SPAN_TYPE]).toBe("root");
+});
+
+test("startTrace with parent ID sets meta.span_type as subroot", () => {
+  const honey = api._apiForTesting().honey;
+  expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
+
+  let rootSpan = api.startTrace({}, "traceId", "parentSpanId");
+
+  expect(rootSpan.payload[schema.META_SPAN_TYPE]).toBe("subroot");
+});

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -152,7 +152,9 @@ module.exports = class LibhoneyEventAPI {
       stack: [],
       dataset: dataset || this.defaultDataset,
     });
-    return this.startSpan(fields, undefined, parentSpanId);
+    let span = this.startSpan(fields, undefined, parentSpanId);
+    span.addContext({ [schema.META_SPAN_TYPE]: parentSpanId ? "subroot": "root"});
+    return span;
   }
 
   finishTrace(span) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -16,6 +16,7 @@ exports.TRACE_SPAN_ID = "trace.span_id";
 exports.TRACE_SERVICE_NAME = "service_name";
 exports.TRACE_SERVICE_DOT_NAME = "service.name";
 exports.TRACE_SPAN_NAME = "name";
+exports.META_SPAN_TYPE = "meta.span_type";
 
 // custom context fields will have this prefix
 exports.customContext = (key) => `app.${key}`;


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for recording whether a span is a root or subroot span within the trace. Root means it is the very first span across all services and subroot means it is the first span within a given service.

When starting a new trace manually, via instrumentation or via propagation, `startTrace` is used so this will ensure that meta.span_type is correctly set.

- Closes #575

## Short description of the changes
- Adds meta.span_type field to lib/schema
- Sets the meta.span_type field when calling startTrace, with either root or subroot depending on if parentSpanId is set
- Add tests to ensure the field is set correctly
