### PR TITLE
maint: make sure ci uses node matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
         default: *default_nodeversion
     executor:
       name: node
+      nodeversion: "<< parameters.nodeversion >>"
     steps:
       - checkout
       - run: npm i


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- CI was using 12.22 node version for all "matrix" jobs
- e.g. [this](https://app.circleci.com/pipelines/github/honeycombio/beeline-nodejs/1885/workflows/7064e35a-e5eb-48ac-8aea-37f58c21b9c0/jobs/12611) was supposed to use 17.0 but if you open "Spin up environment" step it says "Starting container cimg/node:12.22"

## Short description of the changes

- [example 17.0 version run](https://app.circleci.com/pipelines/github/honeycombio/beeline-nodejs/1887/workflows/087ae17c-021d-4b42-87c8-e7af5e324cf6/jobs/12625) from this branch
