### PR TITLE
docs: add note about requiring http

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This package makes it easy to instrument your Express/NodeJS application to send
 
 - Using a bundler (esbuild, webpack, etc.) or ESM with the Beeline is unsupported. You may be able to use the Beeline in those cases, but auto-instrumentations will likely not work.
 
+- An error like `'api.traceActive is not a function' error` may occur for some auto-instrumentation and can be resolved by manually requiring `https` before requiring other libraries such as `request-promise`.
+
 ## Contributions
 
 Features, bug fixes and other changes to `beeline-nodejs` are gladly accepted. Please


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #121 

## Short description of the changes

- This PR just adds a note to the README regarding a potential issue some users may run into. It is sometimes necessary for auto-instrumentation to manually add `require('https');` before requiring in an http request library.
