### PR TITLE
docs: add otel recommendation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![CircleCI](https://circleci.com/gh/honeycombio/beeline-nodejs.svg?style=shield)](https://circleci.com/gh/honeycombio/beeline-nodejs)
 [![npm](https://img.shields.io/npm/v/honeycomb-beeline)](https://www.npmjs.com/package/honeycomb-beeline)
 
+**Note**: Honeycomb embraces OpenTelemetry as the effective way to instrument applications. For any new observability efforts, we recommend [instrumenting with OpenTelemetry](https://docs.honeycomb.io/getting-data-in/opentelemetry/node-distro/).
+
 This package makes it easy to instrument your Express/NodeJS application to send useful events to [Honeycomb](https://honeycomb.io), a service for debugging your software in production.
 
 - [Usage and Examples](https://docs.honeycomb.io/getting-data-in/beelines/nodejs-beeline/)


### PR DESCRIPTION
## Which problem is this PR solving?
This addition to the README makes it clear that Honeycomb recommends instrumenting any new observability efforts with OpenTelemetry

## Short description of the changes
- Add paragraph to README recommending OTel