### PR TITLE
feat: support classic ingest keys, upgrade to libhoney 4.2.0

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -5,6 +5,7 @@ const process = require("process"),
   tracker = require("../async_tracker"),
   pkg = require("../../package.json"),
   debug = require("debug")(`${pkg.name}:event`),
+  libhoney = require("libhoney"),
   LibhoneyImpl = require("./libhoney"),
   MockImpl = require("./mock"),
   utils = require("../util");
@@ -41,7 +42,7 @@ module.exports = {
     apiImpl = new impl(opts);
 
     // tell honeycomb propagator whether we should propagate dataset
-    honeycomb.setPropagateDataset(utils.isClassic(opts.writeKey));
+    honeycomb.setPropagateDataset(libhoney.isClassic(opts.writeKey));
   },
 
   traceActive() {

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -7,8 +7,7 @@ const process = require("process"),
   debug = require("debug")(`${pkg.name}:event`),
   libhoney = require("libhoney"),
   LibhoneyImpl = require("./libhoney"),
-  MockImpl = require("./mock"),
-  utils = require("../util");
+  MockImpl = require("./mock");
 
 const { honeycomb, aws, w3c, util } = propagation;
 

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -29,6 +29,25 @@ test("libhoney default config - classic", () => {
   expect(honey._builder._fields["service.name"]).toBe("unknown_service:nodejs");
 });
 
+test("libhoney default config - classic ingest key", () => {
+  api._resetForTesting();
+  api.configure({
+    impl: "libhoney-event",
+    transmission: "mock",
+    writeKey: "hcaic_1234567890123456789012345678901234567890123456789012345678",
+  });
+
+  const honey = api._apiForTesting().honey;
+  expect(honey.transmission.constructorArg.apiHost).toBe("https://api.honeycomb.io");
+  expect(honey.transmission.constructorArg.dataset).toBe("nodejs");
+  expect(honey.transmission.constructorArg.writeKey).toBe("hcaic_1234567890123456789012345678901234567890123456789012345678");
+  expect(honey.transmission.constructorArg.userAgentAddition).toBe(
+    `honeycomb-beeline/${pkg.version}`
+  );
+  expect(honey._builder._fields["service_name"]).toBe("unknown_service:nodejs");
+  expect(honey._builder._fields["service.name"]).toBe("unknown_service:nodejs");
+});
+
 test("libhoney default config - non-classic", () => {
   api._resetForTesting();
   api.configure({
@@ -41,6 +60,25 @@ test("libhoney default config - non-classic", () => {
   expect(honey.transmission.constructorArg.apiHost).toBe("https://api.honeycomb.io");
   expect(honey.transmission.constructorArg.dataset).toBe("unknown_service");
   expect(honey.transmission.constructorArg.writeKey).toBe("d68f9ed1e96432ac1a3380");
+  expect(honey.transmission.constructorArg.userAgentAddition).toBe(
+    `honeycomb-beeline/${pkg.version}`
+  );
+  expect(honey._builder._fields["service_name"]).toBe("unknown_service:nodejs");
+  expect(honey._builder._fields["service.name"]).toBe("unknown_service:nodejs");
+});
+
+test("libhoney default config - non-classic ingest key", () => {
+  api._resetForTesting();
+  api.configure({
+    impl: "libhoney-event",
+    transmission: "mock",
+    writeKey: "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc",
+  });
+
+  const honey = api._apiForTesting().honey;
+  expect(honey.transmission.constructorArg.apiHost).toBe("https://api.honeycomb.io");
+  expect(honey.transmission.constructorArg.dataset).toBe("unknown_service");
+  expect(honey.transmission.constructorArg.writeKey).toBe("hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc");
   expect(honey.transmission.constructorArg.userAgentAddition).toBe(
     `honeycomb-beeline/${pkg.version}`
   );

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -10,8 +10,7 @@ const libhoney = require("libhoney"),
   schema = require("../schema"),
   Span = require("./span"),
   pkg = require("../../package.json"),
-  debug = require("debug")(`${pkg.name}:event`),
-  util = require("../util");
+  debug = require("debug")(`${pkg.name}:event`);
 
 const defaultName = "nodejs";
 

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -91,7 +91,7 @@ module.exports = class LibhoneyEventAPI {
       console.warn("empty writeKey configuration option");
     }
 
-    if (util.isClassic(opts.writeKey)) {
+    if (libhoney.isClassic(opts.writeKey)) {
       let dataset = opts.dataset || process.env["HONEYCOMB_DATASET"];
       if (!dataset || dataset.trim() === "") {
         dataset = defaultName;

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,9 +17,3 @@ function captureStackTrace(skipFrames = 0, limitFrames = 10) {
   // the +1 here to get rid of the `Error\n` line at the top of the stacktrace.
   return frames.slice(1 + skipFrames).join("\n");
 }
-
-exports.isClassic = isClassic;
-
-function isClassic(writeKey) {
-  return !writeKey || writeKey.length == 32;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/core": "^1.0.0",
         "array-flatten": "^3.0.0",
         "debug": "^4.2.0",
-        "libhoney": "^4.0.0",
+        "libhoney": "^4.2.0",
         "on-headers": "^1.0.2",
         "shimmer": "^1.2.1"
       },
@@ -4549,9 +4549,9 @@
       }
     },
     "node_modules/libhoney": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.1.0.tgz",
-      "integrity": "sha512-U8oCouZXzjlO67wAhDyvnskn9MJFIzTWkxpzsAawUU4nQLMSdISgaGL64eqAeElLRnjlA4hhREr8zOz1So0+yg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.2.0.tgz",
+      "integrity": "sha512-XFb7uP3IPzhTU45pwjBuaRfRyYmnlBEOnbfzdpec538JH5Xds/3sE1UWeYD1IfARuGUFZWQ215b3fbOW+WeFVA==",
       "dependencies": {
         "proxy-agent": "^6.3.0",
         "superagent": "^8.0.0",
@@ -9965,9 +9965,9 @@
       }
     },
     "libhoney": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.1.0.tgz",
-      "integrity": "sha512-U8oCouZXzjlO67wAhDyvnskn9MJFIzTWkxpzsAawUU4nQLMSdISgaGL64eqAeElLRnjlA4hhREr8zOz1So0+yg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.2.0.tgz",
+      "integrity": "sha512-XFb7uP3IPzhTU45pwjBuaRfRyYmnlBEOnbfzdpec538JH5Xds/3sE1UWeYD1IfARuGUFZWQ215b3fbOW+WeFVA==",
       "requires": {
         "proxy-agent": "^6.3.0",
         "superagent": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/core": "^1.0.0",
     "array-flatten": "^3.0.0",
     "debug": "^4.2.0",
-    "libhoney": "^4.0.0",
+    "libhoney": "^4.2.0",
     "on-headers": "^1.0.2",
     "shimmer": "^1.2.1"
   }


### PR DESCRIPTION
## Which problem is this PR solving?

We [recently](https://github.com/honeycombio/libhoney-js/releases/tag/v4.2.0) updated libhoney-js to support classic ingest keys. This PR updates the beeline to this version of libhoney-js and swaps `isClassic` to use the new exported method from libhoney.

## Short description of the changes

- bumps libhoney-js version from `4.0.0` to `4.2.0`
- removes `utils.isClassic` in favor of `libhoney.isClassic`
- Adds two tests that use classic/non-classic ingest keys to verify it works
