### PR TITLE
maint: Bump libhoney to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/core": "^1.0.0",
         "array-flatten": "^3.0.0",
         "debug": "^4.2.0",
-        "libhoney": "^4.2.0",
+        "libhoney": "^4.3.0",
         "on-headers": "^1.0.2",
         "shimmer": "^1.2.1"
       },
@@ -3298,6 +3298,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
       "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dev": true,
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
@@ -4549,16 +4550,60 @@
       }
     },
     "node_modules/libhoney": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.2.0.tgz",
-      "integrity": "sha512-XFb7uP3IPzhTU45pwjBuaRfRyYmnlBEOnbfzdpec538JH5Xds/3sE1UWeYD1IfARuGUFZWQ215b3fbOW+WeFVA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.3.0.tgz",
+      "integrity": "sha512-faxDm2D0Hs7BChPXzyUZSiJXpvAc1JZsY/tHo/QsOE1kF6C+7frLxsszb0gvhDLk+eMSSjRuUMQePrWbGTdhFQ==",
       "dependencies": {
         "proxy-agent": "^6.3.0",
-        "superagent": "^8.0.0",
+        "superagent": "^9.0.1",
         "url-join": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.*"
+        "node": ">= 14.18"
+      }
+    },
+    "node_modules/libhoney/node_modules/formidable": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/libhoney/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/libhoney/node_modules/superagent": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.1.tgz",
+      "integrity": "sha512-CcRSdb/P2oUVaEpQ87w9Obsl+E9FruRd6b2b7LdiBtJoyMr2DQt7a89anAfiX/EL59j9b2CbRFvf2S91DhuCww==",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/light-my-request": {
@@ -6121,6 +6166,7 @@
       "version": "8.0.9",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
       "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+      "dev": true,
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.4",
@@ -6141,6 +6187,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -9042,6 +9089,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
       "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dev": true,
       "requires": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
@@ -9965,13 +10013,47 @@
       }
     },
     "libhoney": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.2.0.tgz",
-      "integrity": "sha512-XFb7uP3IPzhTU45pwjBuaRfRyYmnlBEOnbfzdpec538JH5Xds/3sE1UWeYD1IfARuGUFZWQ215b3fbOW+WeFVA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.3.0.tgz",
+      "integrity": "sha512-faxDm2D0Hs7BChPXzyUZSiJXpvAc1JZsY/tHo/QsOE1kF6C+7frLxsszb0gvhDLk+eMSSjRuUMQePrWbGTdhFQ==",
       "requires": {
         "proxy-agent": "^6.3.0",
-        "superagent": "^8.0.0",
+        "superagent": "^9.0.1",
         "url-join": "^5.0.0"
+      },
+      "dependencies": {
+        "formidable": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+          "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+          "requires": {
+            "dezalgo": "^1.0.4",
+            "hexoid": "^1.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+        },
+        "superagent": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.1.tgz",
+          "integrity": "sha512-CcRSdb/P2oUVaEpQ87w9Obsl+E9FruRd6b2b7LdiBtJoyMr2DQt7a89anAfiX/EL59j9b2CbRFvf2S91DhuCww==",
+          "requires": {
+            "component-emitter": "^1.3.0",
+            "cookiejar": "^2.1.4",
+            "debug": "^4.3.4",
+            "fast-safe-stringify": "^2.1.1",
+            "form-data": "^4.0.0",
+            "formidable": "^3.5.1",
+            "methods": "^1.1.2",
+            "mime": "2.6.0",
+            "qs": "^6.11.0",
+            "semver": "^7.3.8"
+          }
+        }
       }
     },
     "light-my-request": {
@@ -11135,6 +11217,7 @@
       "version": "8.0.9",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
       "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+      "dev": true,
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.4",
@@ -11151,7 +11234,8 @@
         "mime": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/core": "^1.0.0",
     "array-flatten": "^3.0.0",
     "debug": "^4.2.0",
-    "libhoney": "^4.2.0",
+    "libhoney": "^4.3.0",
     "on-headers": "^1.0.2",
     "shimmer": "^1.2.1"
   }


### PR DESCRIPTION
## Which problem is this PR solving?

Updates libhoney-js to latest version which includes resolving a CVE.

## Short description of the changes
- Update libhoney to 4.3.0
